### PR TITLE
Feat add Crave streaming service

### DIFF
--- a/radarr/hd-bluray-web.yml
+++ b/radarr/hd-bluray-web.yml
@@ -49,6 +49,7 @@ radarr:
           # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX

--- a/radarr/remux-web-1080p.yml
+++ b/radarr/remux-web-1080p.yml
@@ -70,6 +70,7 @@ radarr:
           # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX

--- a/radarr/remux-web-2160p.yml
+++ b/radarr/remux-web-2160p.yml
@@ -90,6 +90,7 @@ radarr:
           # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX

--- a/radarr/sqp/sqp-1-2160p.yml
+++ b/radarr/sqp/sqp-1-2160p.yml
@@ -129,6 +129,7 @@ radarr:
           # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX

--- a/radarr/sqp/sqp-1.yml
+++ b/radarr/sqp/sqp-1.yml
@@ -99,6 +99,7 @@ radarr:
           # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX

--- a/radarr/sqp/sqp-2.yml
+++ b/radarr/sqp/sqp-2.yml
@@ -131,6 +131,7 @@ radarr:
           # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX

--- a/radarr/sqp/sqp-3.yml
+++ b/radarr/sqp/sqp-3.yml
@@ -127,6 +127,7 @@ radarr:
           # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX

--- a/radarr/sqp/sqp-4.yml
+++ b/radarr/sqp/sqp-4.yml
@@ -123,6 +123,7 @@ radarr:
           # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX

--- a/radarr/sqp/sqp-5.yml
+++ b/radarr/sqp/sqp-5.yml
@@ -130,6 +130,7 @@ radarr:
           # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX

--- a/radarr/uhd-bluray-web.yml
+++ b/radarr/uhd-bluray-web.yml
@@ -89,6 +89,7 @@ radarr:
           # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX

--- a/sonarr/web-1080p-v4.yml
+++ b/sonarr/web-1080p-v4.yml
@@ -50,3 +50,10 @@ sonarr:
           - d0c516558625b04b363fa6c5c2c7cfd4  # WEB Scene
         quality_profiles:
           - name: WEB-1080p
+
+      - trash_ids:
+          # Streaming Services
+          - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        quality_profiles:
+          - name: WEB-1080p
+            score: 0

--- a/sonarr/web-2160p-v4.yml
+++ b/sonarr/web-2160p-v4.yml
@@ -76,3 +76,10 @@ sonarr:
           - d0c516558625b04b363fa6c5c2c7cfd4  # WEB Scene
         quality_profiles:
           - name: WEB-2160p
+
+      - trash_ids:
+          # Streaming Services
+          - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        quality_profiles:
+          - name: WEB-1080p
+            score: 0

--- a/sonarr/web-2160p-v4.yml
+++ b/sonarr/web-2160p-v4.yml
@@ -81,5 +81,5 @@ sonarr:
           # Streaming Services
           - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         quality_profiles:
-          - name: WEB-1080p
+          - name: WEB-2160p
             score: 0


### PR DESCRIPTION
- Added Crave (CRAV) streaming service to Main Guide and SQP configs for Radarr/Sonarr