### PR TITLE
Maintenance Release 01/08/2023

### DIFF
--- a/radarr/anime-radarr.yml
+++ b/radarr/anime-radarr.yml
@@ -1,8 +1,8 @@
-# Updated: 2023-07-19
+# Updated: 2023-08-01
 radarr:
-  radarr-anime:  # A custom name used to identify this particular instance.
-    base_url: Put your Radarr URL here
-    api_key: Put your API key here
+  anime-radarr:  # A custom name used to identify this particular instance.
+    base_url: [radarr_url_goes_here]
+    api_key: [api_key_goes_here]
 
     quality_definition:
       type: movie

--- a/radarr/hd-bluray-web.yml
+++ b/radarr/hd-bluray-web.yml
@@ -1,8 +1,8 @@
-# Updated: 2023-07-19
+# Updated: 2023-08-01
 radarr:
-  radarr:   # A custom name used to identify this particular instance.
-    base_url: Put your Radarr URL here
-    api_key: Put your API key here
+  hd-bluray-web:   # A custom name used to identify this particular instance.
+    base_url: [radarr_url_goes_here]
+    api_key: [api_key_goes_here]
 
     quality_definition:
       type: movie

--- a/radarr/remux-web-1080p.yml
+++ b/radarr/remux-web-1080p.yml
@@ -1,8 +1,8 @@
-# Updated: 2023-07-19
+# Updated: 2023-08-01
 radarr:
-  radarr:  # A custom name used to identify this particular instance.
-    base_url: Put your Radarr URL here
-    api_key: Put your API key here
+  remux-web-1080p:  # A custom name used to identify this particular instance.
+    base_url: [radarr_url_goes_here]
+    api_key: [api_key_goes_here]
 
     quality_definition:
       type: movie

--- a/radarr/remux-web-2160p.yml
+++ b/radarr/remux-web-2160p.yml
@@ -1,8 +1,8 @@
 # Updated: 2023-07-19
 radarr:
-  radarr:  # A custom name used to identify this particular instance.
-    base_url: Put your Radarr URL here
-    api_key: Put your API key here
+  remux-web-2160p:  # A custom name used to identify this particular instance.
+    base_url: [radarr_url_goes_here]
+    api_key: [api_key_goes_here]
 
     quality_definition:
       type: movie

--- a/radarr/sqp/sqp-1-1080p.yml
+++ b/radarr/sqp/sqp-1-1080p.yml
@@ -1,6 +1,6 @@
 # Updated: 2023-08-01
 radarr:
-  sqp-1-2160p:  # A custom name used to identify this particular instance.
+  sqp-1-1080p:  # A custom name used to identify this particular instance.
     base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 
@@ -8,7 +8,7 @@ radarr:
       type: sqp-streaming
 
     quality_profiles:
-      - name: SQP-1 (2160p)
+      - name: SQP-1 (1080p)
         reset_unmatched_scores: true
 
     custom_formats:
@@ -21,7 +21,7 @@ radarr:
           - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
           - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
         quality_profiles:
-          - name: SQP-1 (2160p)
+          - name: SQP-1 (1080p)
             score: -10000
 
       - trash_ids:
@@ -31,49 +31,36 @@ radarr:
           - 1c1a4c5e823891c75bc50380a6866f73  # DTS
           - 240770601cc226190c367ef59aba7463  # AAC
         quality_profiles:
-          - name: SQP-1 (2160p)
+          - name: SQP-1 (1080p)
             score: 0
 
       - trash_ids:
           - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
         quality_profiles:
-          - name: SQP-1 (2160p)
+          - name: SQP-1 (1080p)
             score: 35
 
       - trash_ids:
           - 185f1dd7264c4562b9022d963ac37424  # DD+
         quality_profiles:
-          - name: SQP-1 (2160p)
+          - name: SQP-1 (1080p)
             score: 25
 
       - trash_ids:
           - c2998bd0d90ed5621d8df281e839436e  # DD
         quality_profiles:
-          - name: SQP-1 (2160p)
+          - name: SQP-1 (1080p)
             score: 15
-
-      # All HDR Formats + DV (WEBDL)
-      - trash_ids:
-          - e23edd2482476e595fb990b12e7c609c  # DV HDR10
-          - 58d6a88f13e2db7f5059c41047876f00  # DV
-          - 55d53828b9d81cbe20b02efd00aa0efd  # DV HLG
-          - a3e19f8f627608af0211acd02bf89735  # DV SDR
-          - b974a6cd08c1066250f1f177d7aa1225  # HDR10+
-          - dfb86d5941bc9075d6af23b09c2aeecd  # HDR10
-          - e61e28db95d22bedcadf030b8f156d96  # HDR
-          - 2a4d9069cc1fe3242ff9bdaebed239bb  # HDR (undefined)
-          - 08d6d8834ad9ec87b1dc7ec8148e7a1f  # PQ
-          - 9364dd386c9b4a1100dde8264690add7  # HLG
-          - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
-
+          
       # Movie Versions
+      - trash_ids:
           - 570bc9ebecd92723d2d21500f4be314c  # Remaster
           - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
           - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
           - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
           - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
           - 957d0f44b592285f26449575e8b1167e  # Special Edition
-          # Uncomment the next line if you prefer 1080p/2160p WEBDL with IMAX Enhanced
+          # Uncomment the next line if you prefer WEBDL with IMAX Enhanced to BHDStudio
           # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
 
       # HQ Release Groups
@@ -82,25 +69,24 @@ radarr:
           - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
           - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
         quality_profiles:
-          - name: SQP-1 (2160p)
+          - name: SQP-1 (1080p)
 
-      # If you use SQP-1 (1080p) as your main/second Radarr, you need to comment out lines 88-104
       - trash_ids:
           - ed27ebfef2f323e964fb1f61391bcb35  # HD Bluray Tier 01
         quality_profiles:
-          - name: SQP-1 (2160p)
+          - name: SQP-1 (1080p)
             score: 1100
 
       - trash_ids:
           - c20c8647f2746a1f4c4262b0fbbeeeae  # HD Bluray Tier 02
         quality_profiles:
-          - name: SQP-1 (2160p)
+          - name: SQP-1 (1080p)
             score: 1050
 
       - trash_ids:
           - 5608c71bcebba0a5e666223bae8c9227  # HD Bluray Tier 03
         quality_profiles:
-          - name: SQP-1 (2160p)
+          - name: SQP-1 (1080p)
             score: 1000
 
       # Misc
@@ -113,42 +99,23 @@ radarr:
           - 90a6f9a284dff5103f6346090e6280c8  # LQ
           - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-          - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
-          - 9c38ebb7384dada637be8899efa68e6f  # SDR
 
       # Optional
           # Uncomment any of the following optional custom formats if you want them to be added to
           # the quality profile
           # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-
-          # Uncomment the next line if you have a setup that supports HDR10+
-          # - b17886cb4158d9fea189859409975758  # HDR10+ Boost
-
           # - 90cedc1fea7ea5d11298bebd3d1d3223  # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
           # - f537cf427b64c38c8e36298f657e4828  # Scene
-
-          # If you want to allow x265 releases that have HDR and/or DV, uncomment
-          # the next line, then comment out line 114
-          # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-
           # - 0a3f082873eb454bde444150b70253cc  # Extras
-
-          # Uncomment lines 140-149 if you want to block AV1 releases
-        # quality_profiles:
-          # - name: SQP-1 (2160p)
-
-      # - trash_ids:
-          # - cae4ca30163749b891686f95532519bd  # AV1
-        # quality_profiles:
-          # - name: SQP-1 (2160p)
-          #   score: -10000
-
-      # - trash_ids:
+          # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
+        quality_profiles:
+          - name: SQP-1 (1080p)
 
       # Resolution
+      - trash_ids:
           - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p
           - b2be17d608fc88818940cd1833b0b24c  # 720p
 
@@ -157,7 +124,7 @@ radarr:
           - 2a6039655313bf5dab1e43523b62c374  # MA
           - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
         quality_profiles:
-          - name: SQP-1 (2160p)
+          - name: SQP-1 (1080p)
 
       - trash_ids:
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
@@ -175,5 +142,5 @@ radarr:
           - e36a0ba1bc902b26ee40818a1d59b8bd  # PMTP
           - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
-          - name: SQP-1 (2160p)
+          - name: SQP-1 (1080p)
             score: 0

--- a/radarr/sqp/sqp-1.yml
+++ b/radarr/sqp/sqp-1.yml
@@ -1,6 +1,8 @@
-# Updated: 2023-07-19
+# Note: Users directly referencing this file, please update to use 'sqp-1-1080p.yml' instead, as
+# this file will soon be removed
+# Updated: 2023-08-01
 radarr:
-  radarr-sqp-streaming:  # A custom name used to identify this particular instance.
+  sqp-1-1080p:  # A custom name used to identify this particular instance.
     base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 
@@ -8,40 +10,99 @@ radarr:
       type: sqp-streaming
 
     quality_profiles:
-      - name: Bluray|WEB-1080p
+      - name: SQP-1 (1080p)
         reset_unmatched_scores: true
 
     custom_formats:
-      # Scores from TRaSH json
+      # Audio
       - trash_ids:
-          # Movie Versions
+          - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
+          - 2f22d89048b01681dde8afe203bf2e95  # DTS X
+          - 3cafb66171b47f226146a0770576870f  # TrueHD
+          - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
+          - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
+          - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
+        quality_profiles:
+          - name: SQP-1 (1080p)
+            score: -10000
+
+      - trash_ids:
+          - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
+          - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
+          - e7c2fcae07cbada050a0af3357491d7b  # PCM
+          - 1c1a4c5e823891c75bc50380a6866f73  # DTS
+          - 240770601cc226190c367ef59aba7463  # AAC
+        quality_profiles:
+          - name: SQP-1 (1080p)
+            score: 0
+
+      - trash_ids:
+          - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
+        quality_profiles:
+          - name: SQP-1 (1080p)
+            score: 35
+
+      - trash_ids:
+          - 185f1dd7264c4562b9022d963ac37424  # DD+
+        quality_profiles:
+          - name: SQP-1 (1080p)
+            score: 25
+
+      - trash_ids:
+          - c2998bd0d90ed5621d8df281e839436e  # DD
+        quality_profiles:
+          - name: SQP-1 (1080p)
+            score: 15
+          
+      # Movie Versions
+      - trash_ids:
           - 570bc9ebecd92723d2d21500f4be314c  # Remaster
           - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
           - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
           - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
           - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
           - 957d0f44b592285f26449575e8b1167e  # Special Edition
-          # Uncomment the next line(s) if you prefer IMAX/IMAX Enhanced to BHDStudio
-          # - eecf3a857724171f968a66cb5719e152  # IMAX
+          # Uncomment the next line if you prefer WEBDL with IMAX Enhanced to BHDStudio
           # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
 
-          # HQ Release Groups
+      # HQ Release Groups
           - 5153ec7413d9dae44e24275589b5e944  # BHDStudio
           - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
           - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
           - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
+        quality_profiles:
+          - name: SQP-1 (1080p)
 
-          # Misc
+      - trash_ids:
+          - ed27ebfef2f323e964fb1f61391bcb35  # HD Bluray Tier 01
+        quality_profiles:
+          - name: SQP-1 (1080p)
+            score: 1100
+
+      - trash_ids:
+          - c20c8647f2746a1f4c4262b0fbbeeeae  # HD Bluray Tier 02
+        quality_profiles:
+          - name: SQP-1 (1080p)
+            score: 1050
+
+      - trash_ids:
+          - 5608c71bcebba0a5e666223bae8c9227  # HD Bluray Tier 03
+        quality_profiles:
+          - name: SQP-1 (1080p)
+            score: 1000
+
+      # Misc
+      - trash_ids:
           - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
 
-          # Unwanted
+      # Unwanted
           - ed38b889b31be83fda192888e2286d83  # BR-DISK
           - 90a6f9a284dff5103f6346090e6280c8  # LQ
-          - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
           - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+          - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
 
-          # Optional
+      # Optional
           # Uncomment any of the following optional custom formats if you want them to be added to
           # the quality profile
           # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
@@ -52,51 +113,22 @@ radarr:
           # - f537cf427b64c38c8e36298f657e4828  # Scene
           # - 0a3f082873eb454bde444150b70253cc  # Extras
           # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
+        quality_profiles:
+          - name: SQP-1 (1080p)
 
-          # Resolution
-          - b2be17d608fc88818940cd1833b0b24c  # 720p
+      # Resolution
+      - trash_ids:
           - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p
+          - b2be17d608fc88818940cd1833b0b24c  # 720p
 
-          # Streaming Services
+      # Streaming Services
           - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
           - 2a6039655313bf5dab1e43523b62c374  # MA
           - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
         quality_profiles:
-          - name: Bluray|WEB-1080p
-
-      # Custom Scoring
-      # HQ Release Groups - Optional
-      # Uncomment the next section (10 lines) to enable other Bluray Encodes (less or not streaming
-      # optimized)
-      # - trash_ids:
-      #     - ed27ebfef2f323e964fb1f61391bcb35  # HD Bluray Tier 01
-      #   quality_profiles:
-      #     - name: Bluray|WEB-1080p
-      #       score: 1100
-      # - trash_ids:
-      #     - c20c8647f2746a1f4c4262b0fbbeeeae  # HD Bluray Tier 02
-      #   quality_profiles:
-      #     - name: Bluray|WEB-1080p
-      #       score: 1050
-      # - trash_ids:
-      #     - 5608c71bcebba0a5e666223bae8c9227  # HD Bluray Tier 03
-      #   quality_profiles:
-      #     - name: Bluray|WEB-1080p
-      #       score: 1000
-      # --HQ Release Groups section ends--
+          - name: SQP-1 (1080p)
 
       - trash_ids:
-          # Audio
-          - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
-          - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
-          - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
-          - e7c2fcae07cbada050a0af3357491d7b  # PCM
-          - 185f1dd7264c4562b9022d963ac37424  # DD+
-          - 1c1a4c5e823891c75bc50380a6866f73  # DTS
-          - 240770601cc226190c367ef59aba7463  # AAC
-          - c2998bd0d90ed5621d8df281e839436e  # DD
-
-          # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
           - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
@@ -112,17 +144,5 @@ radarr:
           - e36a0ba1bc902b26ee40818a1d59b8bd  # PMTP
           - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
-          - name: Bluray|WEB-1080p
+          - name: SQP-1 (1080p)
             score: 0
-
-      - trash_ids:
-          # Audio
-          - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
-          - 2f22d89048b01681dde8afe203bf2e95  # DTS X
-          - 3cafb66171b47f226146a0770576870f  # TrueHD
-          - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
-          - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
-          - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
-        quality_profiles:
-          - name: Bluray|WEB-1080p
-            score: -10000

--- a/radarr/sqp/sqp-2.yml
+++ b/radarr/sqp/sqp-2.yml
@@ -1,6 +1,6 @@
-# Updated: 2023-07-19
+# Updated: 2023-08-01
 radarr:
-  radarr-sqp-uhd:  # A custom name used to identify this particular instance.
+  sqp-2:  # A custom name used to identify this particular instance.
     base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 

--- a/radarr/sqp/sqp-3.yml
+++ b/radarr/sqp/sqp-3.yml
@@ -1,6 +1,6 @@
-# Updated: 2023-07-19
+# Updated: 2023-08-01
 radarr:
-  radarr-sqp-uhd:  # A custom name used to identify this particular instance.
+  sqp-3:  # A custom name used to identify this particular instance.
     base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 

--- a/radarr/sqp/sqp-4.yml
+++ b/radarr/sqp/sqp-4.yml
@@ -1,6 +1,6 @@
-# Updated: 2023-07-19
+# Updated: 2023-08-01
 radarr:
-  radarr-sqp-uhd:  # A custom name used to identify this particular instance.
+  sqp-4:  # A custom name used to identify this particular instance.
     base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 

--- a/radarr/sqp/sqp-5.yml
+++ b/radarr/sqp/sqp-5.yml
@@ -1,6 +1,6 @@
-# Updated: 2023-07-11
+# Updated: 2023-08-01
 radarr:
-  radarr-sqp-uhd:  # A custom name used to identify this particular instance.
+  sqp-5:  # A custom name used to identify this particular instance.
     base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 

--- a/radarr/uhd-bluray-web.yml
+++ b/radarr/uhd-bluray-web.yml
@@ -1,8 +1,8 @@
-# Updated: 2023-07-19
+# Updated: 2023-08-01
 radarr:
-  radarr:  # A custom name used to identify this particular instance.
-    base_url: Put your Radarr URL here
-    api_key: Put your API key here
+  uhd-bluray-web:  # A custom name used to identify this particular instance.
+    base_url: [radarr_url_goes_here]
+    api_key: [api_key_goes_here]
 
     quality_definition:
       type: movie

--- a/sonarr/anime-sonarr-v4.yml
+++ b/sonarr/anime-sonarr-v4.yml
@@ -1,7 +1,7 @@
 # This config file is for use with Sonarr V4 only
-# Updated: 2023-07-19
+# Updated: 2023-08-01
 sonarr:
-  sonarr-anime:  # A custom name used to identify this particular instance.
+  anime-sonarr-v4:  # A custom name used to identify this particular instance.
     base_url: [sonarr_url_goes_here]
     api_key: [api_key_goes_here]
 

--- a/sonarr/web-1080p-v4.yml
+++ b/sonarr/web-1080p-v4.yml
@@ -1,9 +1,9 @@
 # This config file is for use with Sonarr V4 only
-# Updated: 2023-07-19
+# Updated: 2023-08-01
 sonarr:
-  sonarr:  # A custom name used to identify this particular instance.
-    base_url: Put your Sonarr URL here
-    api_key: Put your API key here
+  web-1080p-v4:  # A custom name used to identify this particular instance.
+    base_url: [sonarr_url_goes_here]
+    api_key: [api_key_goes_here]
 
     quality_definition:
       type: series

--- a/sonarr/web-2160p-v4.yml
+++ b/sonarr/web-2160p-v4.yml
@@ -1,9 +1,9 @@
 # This config file is for use with Sonarr V4 only
-# Updated: 2023-07-19
+# Updated: 2023-08-01
 sonarr:
-  sonarr:  # A custom name used to identify this particular instance.
-    base_url: Put your Sonarr URL here
-    api_key: Put your API key here
+  web-2160p-v4:  # A custom name used to identify this particular instance.
+    base_url: [sonarr_url_goes_here]
+    api_key: [api_key_goes_here]
 
     quality_definition:
       type: series


### PR DESCRIPTION
- Renamed SQP-1 to SQP-1 (1080p) in all areas
- Renamed SQP-1 (1080p) and SQP-1 (2160p) quality profiles to SQP-1 (1080p) and SQP-1 (2160p) (i.e., no longer Bluray|WEB-1080p etc.)
- Updated SQP-1 (1080p) and SQP-1 (2160p) config templates to match updated guides
- Reformatted SQP-1 (1080p) and SQP-1 (2160p) config templates to match guide layout (i.e., no longer split by standard/custom scoring)
- Updated all config templates to use an instance name that matches the name of the template
- Updated base_url and api_key fields to be consistent across all config templates