### PR TITLE
Fix: Removed array/sequence syntax from base_url and api_key placeholders.

### DIFF
--- a/radarr/anime-radarr.yml
+++ b/radarr/anime-radarr.yml
@@ -1,8 +1,8 @@
 # Updated: 2023-08-01
 radarr:
   anime-radarr:  # A custom name used to identify this particular instance.
-    base_url: [radarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Radarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: movie

--- a/radarr/hd-bluray-web.yml
+++ b/radarr/hd-bluray-web.yml
@@ -1,8 +1,8 @@
 # Updated: 2023-08-01
 radarr:
   hd-bluray-web:   # A custom name used to identify this particular instance.
-    base_url: [radarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Radarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: movie

--- a/radarr/remux-web-1080p.yml
+++ b/radarr/remux-web-1080p.yml
@@ -1,8 +1,8 @@
 # Updated: 2023-08-01
 radarr:
   remux-web-1080p:  # A custom name used to identify this particular instance.
-    base_url: [radarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Radarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: movie

--- a/radarr/remux-web-2160p.yml
+++ b/radarr/remux-web-2160p.yml
@@ -1,8 +1,8 @@
 # Updated: 2023-07-19
 radarr:
   remux-web-2160p:  # A custom name used to identify this particular instance.
-    base_url: [radarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Radarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: movie

--- a/radarr/sqp/sqp-1-1080p.yml
+++ b/radarr/sqp/sqp-1-1080p.yml
@@ -1,8 +1,8 @@
 # Updated: 2023-08-01
 radarr:
   sqp-1-1080p:  # A custom name used to identify this particular instance.
-    base_url: [radarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Radarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: sqp-streaming

--- a/radarr/sqp/sqp-1-2160p.yml
+++ b/radarr/sqp/sqp-1-2160p.yml
@@ -1,8 +1,8 @@
 # Updated: 2023-08-01
 radarr:
   sqp-1-2160p:  # A custom name used to identify this particular instance.
-    base_url: [radarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Radarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: sqp-streaming

--- a/radarr/sqp/sqp-1.yml
+++ b/radarr/sqp/sqp-1.yml
@@ -3,8 +3,8 @@
 # Updated: 2023-08-01
 radarr:
   sqp-1-1080p:  # A custom name used to identify this particular instance.
-    base_url: [radarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Radarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: sqp-streaming

--- a/radarr/sqp/sqp-2.yml
+++ b/radarr/sqp/sqp-2.yml
@@ -1,8 +1,8 @@
 # Updated: 2023-08-01
 radarr:
   sqp-2:  # A custom name used to identify this particular instance.
-    base_url: [radarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Radarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: sqp-uhd

--- a/radarr/sqp/sqp-3.yml
+++ b/radarr/sqp/sqp-3.yml
@@ -1,8 +1,8 @@
 # Updated: 2023-08-01
 radarr:
   sqp-3:  # A custom name used to identify this particular instance.
-    base_url: [radarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Radarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: sqp-uhd

--- a/radarr/sqp/sqp-4.yml
+++ b/radarr/sqp/sqp-4.yml
@@ -1,8 +1,8 @@
 # Updated: 2023-08-01
 radarr:
   sqp-4:  # A custom name used to identify this particular instance.
-    base_url: [radarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Radarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: sqp-uhd

--- a/radarr/sqp/sqp-5.yml
+++ b/radarr/sqp/sqp-5.yml
@@ -1,8 +1,8 @@
 # Updated: 2023-08-01
 radarr:
   sqp-5:  # A custom name used to identify this particular instance.
-    base_url: [radarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Radarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: sqp-uhd

--- a/radarr/uhd-bluray-web.yml
+++ b/radarr/uhd-bluray-web.yml
@@ -1,8 +1,8 @@
 # Updated: 2023-08-01
 radarr:
   uhd-bluray-web:  # A custom name used to identify this particular instance.
-    base_url: [radarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Radarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: movie

--- a/sonarr/anime-sonarr-v4.yml
+++ b/sonarr/anime-sonarr-v4.yml
@@ -2,8 +2,8 @@
 # Updated: 2023-08-01
 sonarr:
   anime-sonarr-v4:  # A custom name used to identify this particular instance.
-    base_url: [sonarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Sonarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: anime

--- a/sonarr/web-1080p-v4.yml
+++ b/sonarr/web-1080p-v4.yml
@@ -2,8 +2,8 @@
 # Updated: 2023-08-01
 sonarr:
   web-1080p-v4:  # A custom name used to identify this particular instance.
-    base_url: [sonarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Sonarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: series

--- a/sonarr/web-2160p-v4.yml
+++ b/sonarr/web-2160p-v4.yml
@@ -2,8 +2,8 @@
 # Updated: 2023-08-01
 sonarr:
   web-2160p-v4:  # A custom name used to identify this particular instance.
-    base_url: [sonarr_url_goes_here]
-    api_key: [api_key_goes_here]
+    base_url: Put your Sonarr URL here
+    api_key: Put your API key here
 
     quality_definition:
       type: series


### PR DESCRIPTION
- Removed array/sequence syntax from base_url and api_key placeholders.