### PR TITLE
Use new reset_unmatched_scores syntax

### DIFF
--- a/radarr/anime-radarr.yml
+++ b/radarr/anime-radarr.yml
@@ -27,7 +27,8 @@ radarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: Remux-1080p - Anime
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           until_quality: Remux-1080p

--- a/radarr/french-hd-bluray-web-multi.yml
+++ b/radarr/french-hd-bluray-web-multi.yml
@@ -16,7 +16,8 @@ radarr:
 
     quality_profiles:
       - name: FR-MULTi-BLURAY-WEB-1080p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     # La liste de Formats Personnalisés à synchroniser avec Radarr.
     custom_formats:

--- a/radarr/french-hd-bluray-web-vostfr.yml
+++ b/radarr/french-hd-bluray-web-vostfr.yml
@@ -17,7 +17,8 @@ radarr:
 
     quality_profiles:
       - name: FR-VOSTFR-BLURAY-WEB-1080p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     # La liste de Formats Personnalisés à synchroniser avec Radarr.
     custom_formats:

--- a/radarr/french-remux-web-1080p-multi.yml
+++ b/radarr/french-remux-web-1080p-multi.yml
@@ -16,7 +16,8 @@ radarr:
 
     quality_profiles:
       - name: FR-MULTi-REMUX-WEB-1080p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     # La liste de Formats Personnalisés à synchroniser avec Radarr.
     custom_formats:

--- a/radarr/french-remux-web-1080p-vostfr.yml
+++ b/radarr/french-remux-web-1080p-vostfr.yml
@@ -17,7 +17,8 @@ radarr:
 
     quality_profiles:
       - name: FR-VOSTFR-REMUX-WEB-1080p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     # La liste de Formats Personnalisés à synchroniser avec Radarr.
     custom_formats:

--- a/radarr/french-remux-web-2160p-multi.yml
+++ b/radarr/french-remux-web-2160p-multi.yml
@@ -16,7 +16,8 @@ radarr:
 
     quality_profiles:
       - name: FR-MULTi-REMUX-WEB-2160p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     # La liste de Formats Personnalisés à synchroniser avec Radarr.
     custom_formats:

--- a/radarr/french-remux-web-2160p-vostfr.yml
+++ b/radarr/french-remux-web-2160p-vostfr.yml
@@ -17,7 +17,8 @@ radarr:
 
     quality_profiles:
       - name: FR-VOSTFR-REMUX-WEB-2160p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     # La liste de Formats Personnalisés à synchroniser avec Radarr.
     custom_formats:

--- a/radarr/french-uhd-bluray-web-multi.yml
+++ b/radarr/french-uhd-bluray-web-multi.yml
@@ -16,7 +16,8 @@ radarr:
 
     quality_profiles:
       - name: FR-MULTi-BLURAY-WEB-2160p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     # La liste de Formats Personnalisés à synchroniser avec Radarr.
     custom_formats:

--- a/radarr/french-uhd-bluray-web-vostfr.yml
+++ b/radarr/french-uhd-bluray-web-vostfr.yml
@@ -17,7 +17,8 @@ radarr:
 
     quality_profiles:
       - name: FR-VOSTFR-BLURAY-WEB-2160p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     # La liste de Formats Personnalisés à synchroniser avec Radarr.
     custom_formats:

--- a/radarr/hd-bluray-web.yml
+++ b/radarr/hd-bluray-web.yml
@@ -27,7 +27,8 @@ radarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: HD Bluray + WEB
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           until_quality: Bluray-1080p

--- a/radarr/remux-web-1080p.yml
+++ b/radarr/remux-web-1080p.yml
@@ -27,7 +27,8 @@ radarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: Remux + WEB 1080p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           until_quality: Remux-1080p
@@ -63,7 +64,7 @@ radarr:
           # - 1c1a4c5e823891c75bc50380a6866f73  # DTS
           # - 240770601cc226190c367ef59aba7463  # AAC
           # - c2998bd0d90ed5621d8df281e839436e  # DD
-          
+
           # Movie Versions
           - 0f12c086e289cf966fa5948eac571f44  # Hybrid
           - 570bc9ebecd92723d2d21500f4be314c  # Remaster
@@ -74,7 +75,7 @@ radarr:
           - 957d0f44b592285f26449575e8b1167e  # Special Edition
           - eecf3a857724171f968a66cb5719e152  # IMAX
           - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
-          
+
           # HQ Release Groups
           - 3a3ff47579026e76d6504ebea39390de  # Remux Tier 01
           - 9f98181fe5a3fbeb0cc29340da2a468a  # Remux Tier 02
@@ -82,17 +83,17 @@ radarr:
           - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
           - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
           - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
-          
+
           # Misc
           - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
-          
+
           # Unwanted
           - ed38b889b31be83fda192888e2286d83  # BR-DISK
           - 90a6f9a284dff5103f6346090e6280c8  # LQ
           - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-          
+
           # Streaming Services
           - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
           - 2a6039655313bf5dab1e43523b62c374  # MA

--- a/radarr/remux-web-2160p.yml
+++ b/radarr/remux-web-2160p.yml
@@ -27,7 +27,8 @@ radarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: Remux + WEB 2160p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           until_quality: Remux-2160p

--- a/radarr/sqp/sqp-1-1080p.yml
+++ b/radarr/sqp/sqp-1-1080p.yml
@@ -27,7 +27,8 @@ radarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: SQP-1 (1080p)
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           until_quality: Bluray|WEB-1080p
@@ -91,7 +92,7 @@ radarr:
         quality_profiles:
           - name: SQP-1 (1080p)
             score: 115
-          
+
       # Movie Versions
       - trash_ids:
           - 570bc9ebecd92723d2d21500f4be314c  # Remaster

--- a/radarr/sqp/sqp-1-2160p.yml
+++ b/radarr/sqp/sqp-1-2160p.yml
@@ -27,7 +27,8 @@ radarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: SQP-1 (2160p)
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           # If you prefer 2160p WEBDL releases with IMAX-E, comment out line 35, and

--- a/radarr/sqp/sqp-2.yml
+++ b/radarr/sqp/sqp-2.yml
@@ -27,7 +27,8 @@ radarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: SQP-2
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           until_quality: WEB|Remux|Bluray|2160p
@@ -91,7 +92,7 @@ radarr:
             # score: 0
 
       # Movie Versions
-      - trash_ids: 
+      - trash_ids:
           - 0f12c086e289cf966fa5948eac571f44  # Hybrid
           - f700d29429c023a5734505e77daeaea7  # DV (FEL)
           - 570bc9ebecd92723d2d21500f4be314c  # Remaster
@@ -168,7 +169,7 @@ radarr:
           # - f537cf427b64c38c8e36298f657e4828  # Scene
           # - 0a3f082873eb454bde444150b70253cc  # Extras
         quality_profiles:
-          - name: SQP-2        
+          - name: SQP-2
 
       # Resolution
       - trash_ids:

--- a/radarr/sqp/sqp-3.yml
+++ b/radarr/sqp/sqp-3.yml
@@ -27,7 +27,8 @@ radarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: SQP-3
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           until_quality: WEB|Remux|2160p
@@ -90,7 +91,7 @@ radarr:
             # score: 0
 
       # Movie Versions
-      - trash_ids: 
+      - trash_ids:
           - 0f12c086e289cf966fa5948eac571f44  # Hybrid
           - f700d29429c023a5734505e77daeaea7  # DV (FEL)
           - 570bc9ebecd92723d2d21500f4be314c  # Remaster

--- a/radarr/sqp/sqp-4.yml
+++ b/radarr/sqp/sqp-4.yml
@@ -27,7 +27,8 @@ radarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: SQP-4
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           until_quality: WEB|2160p
@@ -89,7 +90,7 @@ radarr:
             # score: 0
 
       # Movie Versions
-      - trash_ids: 
+      - trash_ids:
           - 0f12c086e289cf966fa5948eac571f44  # Hybrid
           - f700d29429c023a5734505e77daeaea7  # DV (FEL)
           - 570bc9ebecd92723d2d21500f4be314c  # Remaster

--- a/radarr/sqp/sqp-5.yml
+++ b/radarr/sqp/sqp-5.yml
@@ -27,7 +27,8 @@ radarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: SQP-5
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           until_quality: WEB|Bluray|2160p
@@ -90,7 +91,7 @@ radarr:
             # score: 0
 
       # Movie Versions
-      - trash_ids: 
+      - trash_ids:
           - 0f12c086e289cf966fa5948eac571f44  # Hybrid
           - f700d29429c023a5734505e77daeaea7  # DV (FEL)
           - 570bc9ebecd92723d2d21500f4be314c  # Remaster

--- a/radarr/uhd-bluray-web.yml
+++ b/radarr/uhd-bluray-web.yml
@@ -27,7 +27,8 @@ radarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: UHD Bluray + WEB
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           until_quality: Bluray-2160p

--- a/sonarr/anime-sonarr-v4.yml
+++ b/sonarr/anime-sonarr-v4.yml
@@ -28,7 +28,8 @@ sonarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: Remux-1080p - Anime
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           until_quality: Bluray-1080p

--- a/sonarr/french-anime-multi-v4.yml
+++ b/sonarr/french-anime-multi-v4.yml
@@ -15,7 +15,8 @@ sonarr:
 
     quality_profiles:
       - name: FR-ANIME-MULTi
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     custom_formats:
       # La liste de Formats Personnalisés à synchroniser avec Sonarr.

--- a/sonarr/french-anime-vostfr-v4.yml
+++ b/sonarr/french-anime-vostfr-v4.yml
@@ -15,7 +15,8 @@ sonarr:
 
     quality_profiles:
       - name: FR-ANIME-VOSTFR
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     # La liste de Formats Personnalisés à synchroniser avec Sonarr.
     custom_formats:

--- a/sonarr/french-web-1080p-multi-v4.yml
+++ b/sonarr/french-web-1080p-multi-v4.yml
@@ -15,7 +15,8 @@ sonarr:
 
     quality_profiles:
       - name: FR-MULTi-WEB-1080p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     # La liste de Formats Personnalisés à synchroniser avec Sonarr.
     custom_formats:

--- a/sonarr/french-web-1080p-vostfr-v4.yml
+++ b/sonarr/french-web-1080p-vostfr-v4.yml
@@ -15,7 +15,8 @@ sonarr:
 
     quality_profiles:
       - name: FR-VOSTFR-WEB-1080p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     # La liste de Formats Personnalisés à synchroniser avec Sonarr.
     custom_formats:

--- a/sonarr/french-web-2160p-multi-v4.yml
+++ b/sonarr/french-web-2160p-multi-v4.yml
@@ -15,7 +15,8 @@ sonarr:
 
     quality_profiles:
       - name: FR-MULTi-WEB-2160p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     # La liste de Formats Personnalisés à synchroniser avec Sonarr.
     custom_formats:

--- a/sonarr/french-web-2160p-vostfr-v4.yml
+++ b/sonarr/french-web-2160p-vostfr-v4.yml
@@ -15,7 +15,8 @@ sonarr:
 
     quality_profiles:
       - name: FR-VOSTFR-WEB-2160p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
 
     # La liste de Formats Personnalisés à synchroniser avec Sonarr.
     custom_formats:

--- a/sonarr/web-1080p-v4.yml
+++ b/sonarr/web-1080p-v4.yml
@@ -28,7 +28,8 @@ sonarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: WEB-1080p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           until_quality: WEB 1080p

--- a/sonarr/web-2160p-v4.yml
+++ b/sonarr/web-2160p-v4.yml
@@ -24,7 +24,8 @@ sonarr:
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#quality-profiles
     quality_profiles:
       - name: WEB-2160p
-        reset_unmatched_scores: true
+        reset_unmatched_scores:
+          enabled: true
         upgrade:
           allowed: true
           until_quality: WEB 2160p


### PR DESCRIPTION
This new syntax was introduced in v5.3.0. See deprecation notice here: https://recyclarr.dev/wiki/upgrade-guide/v6.0/#reset-scores