### PR TITLE
Feature: Add Score Sets to SQP config files

### DIFF
--- a/radarr/sqp/sqp-1-1080p.yml
+++ b/radarr/sqp/sqp-1-1080p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (1080p)                                                 #
-# Updated: 2023-08-16                                                                             #
+# Updated: 2023-08-27                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -33,10 +33,8 @@ radarr:
           allowed: true
           until_quality: Bluray|WEB-1080p
           until_score: 10000
-        # If you're limited to public indexers, don't have access to top-tier indexers, or are
-        # searching for content that is more rare, you might want to lower the min_format_score
-        # to 10.
-        min_format_score: 1000
+        min_format_score: 1000  # Change to 10 if you don't have access to top-tier indexers
+        score_set: sqp-1-1080p
         quality_sort: top
         qualities:
           - name: Bluray|WEB-1080p
@@ -53,48 +51,24 @@ radarr:
 # and applies them and their scores to Quality Profiles
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#custom-format-settings
     custom_formats:
-      # Audio
       - trash_ids:
+      # Audio
           - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
           - 2f22d89048b01681dde8afe203bf2e95  # DTS X
+          - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
+          - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
           - 3cafb66171b47f226146a0770576870f  # TrueHD
           - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
-          - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
-          - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
-        quality_profiles:
-          - name: SQP-1 (1080p)
-            score: -10000
-
-      - trash_ids:
-          - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
           - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
           - e7c2fcae07cbada050a0af3357491d7b  # PCM
+          - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
+          - 185f1dd7264c4562b9022d963ac37424  # DD+
+          - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
           - 1c1a4c5e823891c75bc50380a6866f73  # DTS
           - 240770601cc226190c367ef59aba7463  # AAC
-        quality_profiles:
-          - name: SQP-1 (1080p)
-            score: 0
-
-      - trash_ids:
-          - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
-        quality_profiles:
-          - name: SQP-1 (1080p)
-            score: 135
-
-      - trash_ids:
-          - 185f1dd7264c4562b9022d963ac37424  # DD+
-        quality_profiles:
-          - name: SQP-1 (1080p)
-            score: 125
-
-      - trash_ids:
           - c2998bd0d90ed5621d8df281e839436e  # DD
-        quality_profiles:
-          - name: SQP-1 (1080p)
-            score: 115
 
       # Movie Versions
-      - trash_ids:
           - 570bc9ebecd92723d2d21500f4be314c  # Remaster
           - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
           - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
@@ -109,29 +83,11 @@ radarr:
           - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
           - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
           - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
-        quality_profiles:
-          - name: SQP-1 (1080p)
-
-      - trash_ids:
           - ed27ebfef2f323e964fb1f61391bcb35  # HD Bluray Tier 01
-        quality_profiles:
-          - name: SQP-1 (1080p)
-            score: 1100
-
-      - trash_ids:
           - c20c8647f2746a1f4c4262b0fbbeeeae  # HD Bluray Tier 02
-        quality_profiles:
-          - name: SQP-1 (1080p)
-            score: 1050
-
-      - trash_ids:
           - 5608c71bcebba0a5e666223bae8c9227  # HD Bluray Tier 03
-        quality_profiles:
-          - name: SQP-1 (1080p)
-            score: 1000
 
       # Misc
-      - trash_ids:
           - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
 
@@ -152,29 +108,22 @@ radarr:
           # - f537cf427b64c38c8e36298f657e4828  # Scene
           # - 0a3f082873eb454bde444150b70253cc  # Extras
           # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
-        quality_profiles:
-          - name: SQP-1 (1080p)
 
       # Resolution
-      - trash_ids:
           - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p
           - b2be17d608fc88818940cd1833b0b24c  # 720p
 
       # Streaming Services
-          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
-          - 2a6039655313bf5dab1e43523b62c374  # MA
-          - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
-        quality_profiles:
-          - name: SQP-1 (1080p)
-
-      - trash_ids:
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
           - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+          - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
           - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 2a6039655313bf5dab1e43523b62c374  # MA
           - 6a061313d22e51e0f25b7cd4dc065233  # MAX
           - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
           - fbca986396c5e695ef7b2def3c755d01  # OViD
@@ -184,4 +133,3 @@ radarr:
           - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: SQP-1 (1080p)
-            score: 0

--- a/radarr/sqp/sqp-1-2160p.yml
+++ b/radarr/sqp/sqp-1-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (2160p)                                                 #
-# Updated: 2023-08-16 v2                                                                          #
+# Updated: 2023-08-27                                                                          #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -31,30 +31,33 @@ radarr:
           enabled: true
         upgrade:
           allowed: true
-          # If you prefer 2160p WEBDL releases with IMAX-E, comment out line 35, and
-          # uncomment line 36
+        # Choose from the following options:
+        # Use lines 38-48 for the default profile behaviour, OR
+        # comment out lines 38-48, and uncomment lines 49-59 if you
+        # prefer 2160p WEBDL releases with IMAX-E
           until_quality: Bluray-2160p
-          # until_quality: Bluray|WEB-2160p
           until_score: 10000
-        # If you're limited to public indexers, don't have access to top-tier indexers, or are
-        # searching for content that is more rare, you might want to lower the min_format_score
-        # to 10.
-        min_format_score: 1000
+        min_format_score: 1000  # Change to 10 if you don't have access to top-tier indexers
+        score_set: sqp-1-2160p
         quality_sort: top
         qualities:
-          # If you prefer 2160p WEBDL releases with IMAX-E, comment out lines 46-50, and
-          # uncomment lines 51-55
           - name: Bluray-2160p
           - name: WEB-2160p
             qualities:
               - WEBDL-2160p
               - WEBRip-2160p
+          # until_quality: Bluray|WEB-2160p
+          # until_score: 10000
+        # min_format_score: 1000  # Change to 10 if you don't have access to top-tier indexers
+        # score_set: sqp-1-2160p
+        # quality_sort: top
+        # qualities:
           # - name: Bluray|WEB-2160p
             # qualities:
               # - Bluray-2160p
               # - WEBDL-2160p
               # - WEBRip-2160p
-          # If you use SQP-1 (1080p) in another instance of Radarr, comment out lines 57-64
+          # If you use SQP-1 (1080p) in another instance of Radarr, comment out lines 61-68
           - name: Bluray|WEB-1080p
             qualities:
               - Bluray-1080p
@@ -69,48 +72,24 @@ radarr:
 # and applies them and their scores to Quality Profiles
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#custom-format-settings
     custom_formats:
-      # Audio
       - trash_ids:
+      # Audio
           - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
           - 2f22d89048b01681dde8afe203bf2e95  # DTS X
+          - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
+          - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
           - 3cafb66171b47f226146a0770576870f  # TrueHD
           - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
-          - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
-          - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
-        quality_profiles:
-          - name: SQP-1 (2160p)
-            score: -10000
-
-      - trash_ids:
-          - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
           - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
           - e7c2fcae07cbada050a0af3357491d7b  # PCM
+          - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
+          - 185f1dd7264c4562b9022d963ac37424  # DD+
+          - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
           - 1c1a4c5e823891c75bc50380a6866f73  # DTS
           - 240770601cc226190c367ef59aba7463  # AAC
-        quality_profiles:
-          - name: SQP-1 (2160p)
-            score: 0
-
-      - trash_ids:
-          - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
-        quality_profiles:
-          - name: SQP-1 (2160p)
-            score: 135
-
-      - trash_ids:
-          - 185f1dd7264c4562b9022d963ac37424  # DD+
-        quality_profiles:
-          - name: SQP-1 (2160p)
-            score: 125
-
-      - trash_ids:
           - c2998bd0d90ed5621d8df281e839436e  # DD
-        quality_profiles:
-          - name: SQP-1 (2160p)
-            score: 115
 
       # All HDR Formats + DV (WEBDL)
-      - trash_ids:
           - e23edd2482476e595fb990b12e7c609c  # DV HDR10
           - 58d6a88f13e2db7f5059c41047876f00  # DV
           - 55d53828b9d81cbe20b02efd00aa0efd  # DV HLG
@@ -138,29 +117,11 @@ radarr:
           - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
           - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
           - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
-        quality_profiles:
-          - name: SQP-1 (2160p)
-
-      - trash_ids:
           - ed27ebfef2f323e964fb1f61391bcb35  # HD Bluray Tier 01
-        quality_profiles:
-          - name: SQP-1 (2160p)
-            score: 1100
-
-      - trash_ids:
           - c20c8647f2746a1f4c4262b0fbbeeeae  # HD Bluray Tier 02
-        quality_profiles:
-          - name: SQP-1 (2160p)
-            score: 1050
-
-      - trash_ids:
           - 5608c71bcebba0a5e666223bae8c9227  # HD Bluray Tier 03
-        quality_profiles:
-          - name: SQP-1 (2160p)
-            score: 1000
 
       # Misc
-      - trash_ids:
           - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
 
@@ -168,7 +129,7 @@ radarr:
           - ed38b889b31be83fda192888e2286d83  # BR-DISK
           - 90a6f9a284dff5103f6346090e6280c8  # LQ
           # If you want to use x265 (HD) instead of x265 (no HDR/DV) then
-          # uncomment the next line, and comment out line 188. Do not use both.
+          # uncomment the next line, and comment out line 150. Do not use both.
           # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
           - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
@@ -184,41 +145,29 @@ radarr:
           # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
           # - f537cf427b64c38c8e36298f657e4828  # Scene
-          # If you also want to block x265 releases that have HDR and/or DV, comment out
-          # the next line, then uncomment line 171. Do not use both.
+          # If you want to block x265 releases that have HDR and/or DV, comment out
+          # the next line, then uncomment line 133. Do not use both.
           - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           # - 0a3f082873eb454bde444150b70253cc  # Extras
           - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        quality_profiles:
-          - name: SQP-1 (2160p)
-
-          # Comment out lines 195-199 if you don't want to block AV1 releases
-      - trash_ids:
+          # Comment out the next line if you don't want to block AV1 releases
           - cae4ca30163749b891686f95532519bd  # AV1
-        quality_profiles:
-          - name: SQP-1 (2160p)
-            score: -10000
 
-      - trash_ids:
       # Resolution
           - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p
           - b2be17d608fc88818940cd1833b0b24c  # 720p
 
       # Streaming Services
-          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
-          - 2a6039655313bf5dab1e43523b62c374  # MA
-          - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
-        quality_profiles:
-          - name: SQP-1 (2160p)
-
-      - trash_ids:
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
           - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+          - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
           - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 2a6039655313bf5dab1e43523b62c374  # MA
           - 6a061313d22e51e0f25b7cd4dc065233  # MAX
           - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
           - fbca986396c5e695ef7b2def3c755d01  # OViD
@@ -228,4 +177,3 @@ radarr:
           - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: SQP-1 (2160p)
-            score: 0

--- a/radarr/sqp/sqp-2.yml
+++ b/radarr/sqp/sqp-2.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-2                                                         #
-# Updated: 2023-08-15                                                                             #
+# Updated: 2023-08-27                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -34,6 +34,7 @@ radarr:
           until_quality: WEB|Remux|Bluray|2160p
           until_score: 10000
         min_format_score: 550
+        score_set: sqp-2
         quality_sort: top
         qualities:
           - name: WEB|Remux|Bluray|2160p
@@ -51,8 +52,8 @@ radarr:
 # and applies them and their scores to Quality Profiles
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#custom-format-settings
     custom_formats:
-      # Audio
       - trash_ids:
+      # Audio
           - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
           - 2f22d89048b01681dde8afe203bf2e95  # DTS X
           - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
@@ -79,20 +80,10 @@ radarr:
           - 2a4d9069cc1fe3242ff9bdaebed239bb  # HDR (undefined)
           - 08d6d8834ad9ec87b1dc7ec8148e7a1f  # PQ
           - 9364dd386c9b4a1100dde8264690add7  # HLG
-        quality_profiles:
-          - name: SQP-2
-
-      - trash_ids:
-          # DV (WEBDL)
+          # Uncomment the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
-        quality_profiles:
-          - name: SQP-2
-            # If you and all of your users have a setup that fully supports DV, then uncomment the
-            # next line to override the default DV (WEBDL) score of -10000
-            # score: 0
 
       # Movie Versions
-      - trash_ids:
           - 0f12c086e289cf966fa5948eac571f44  # Hybrid
           - f700d29429c023a5734505e77daeaea7  # DV (FEL)
           - 570bc9ebecd92723d2d21500f4be314c  # Remaster
@@ -109,28 +100,9 @@ radarr:
           - 3a3ff47579026e76d6504ebea39390de  # Remux Tier 01
           - 9f98181fe5a3fbeb0cc29340da2a468a  # Remux Tier 02
           - 8baaf0b3142bf4d94c42a724f034e27a  # Remux Tier 03
-        quality_profiles:
-          - name: SQP-2
-
-      - trash_ids:
           - 4d74ac4c4db0b64bff6ce0cffef99bf0  # UHD Bluray Tier 01
-        quality_profiles:
-          - name: SQP-2
-            score: 2300
-
-      - trash_ids:
           - a58f517a70193f8e578056642178419d  # UHD Bluray Tier 02
-        quality_profiles:
-          - name: SQP-2
-            score: 2200
-
-      - trash_ids:
           - e71939fae578037e7aed3ee219bbe7c1  # UHD Bluray Tier 03
-        quality_profiles:
-          - name: SQP-2
-            score: 2100
-
-      - trash_ids:
           - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
           - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
           - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
@@ -138,17 +110,9 @@ radarr:
       # Misc
           - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
-        quality_profiles:
-          - name: SQP-2
-
-      - trash_ids:
           - 2899d84dc9372de3408e6d8cc18e9666  # x264
-        quality_profiles:
-          - name: SQP-2
-            score: -10000
 
       # Unwanted
-      - trash_ids:
           - ed38b889b31be83fda192888e2286d83  # BR-DISK
           - 90a6f9a284dff5103f6346090e6280c8  # LQ
           - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
@@ -168,38 +132,22 @@ radarr:
           # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
           # - f537cf427b64c38c8e36298f657e4828  # Scene
           # - 0a3f082873eb454bde444150b70253cc  # Extras
-        quality_profiles:
-          - name: SQP-2
 
       # Resolution
-      - trash_ids:
           - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p
-        quality_profiles:
-          - name: SQP-2
-
-      - trash_ids:
           - fb392fb0d61a010ae38e49ceaa24a1ef  # 2160p
-        quality_profiles:
-          - name: SQP-2
-            score: 151
 
       # Streaming Services
-      - trash_ids:
-          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
-          - 2a6039655313bf5dab1e43523b62c374  # MA
-          - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
-        quality_profiles:
-          - name: SQP-2
-
-      - trash_ids:
-          # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
           - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+          - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
           - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 2a6039655313bf5dab1e43523b62c374  # MA
           - 6a061313d22e51e0f25b7cd4dc065233  # MAX
           - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
           - fbca986396c5e695ef7b2def3c755d01  # OViD
@@ -209,4 +157,3 @@ radarr:
           - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: SQP-2
-            score: 0

--- a/radarr/sqp/sqp-3.yml
+++ b/radarr/sqp/sqp-3.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-3                                                         #
-# Updated: 2023-08-15                                                                             #
+# Updated: 2023-08-27                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -34,6 +34,7 @@ radarr:
           until_quality: WEB|Remux|2160p
           until_score: 10000
         min_format_score: 550
+        score_set: sqp-3
         quality_sort: top
         qualities:
           - name: WEB|Remux|2160p
@@ -50,8 +51,8 @@ radarr:
 # and applies them and their scores to Quality Profiles
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#custom-format-settings
     custom_formats:
-      # Audio
       - trash_ids:
+      # Audio
           - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
           - 2f22d89048b01681dde8afe203bf2e95  # DTS X
           - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
@@ -78,20 +79,10 @@ radarr:
           - 2a4d9069cc1fe3242ff9bdaebed239bb  # HDR (undefined)
           - 08d6d8834ad9ec87b1dc7ec8148e7a1f  # PQ
           - 9364dd386c9b4a1100dde8264690add7  # HLG
-        quality_profiles:
-          - name: SQP-3
-
-      - trash_ids:
-          # DV (WEBDL)
+          # Uncomment the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
-        quality_profiles:
-          - name: SQP-3
-            # If you and all of your users have a setup that fully supports DV, then uncomment the
-            # next line to override the default DV (WEBDL) score of -10000
-            # score: 0
 
       # Movie Versions
-      - trash_ids:
           - 0f12c086e289cf966fa5948eac571f44  # Hybrid
           - f700d29429c023a5734505e77daeaea7  # DV (FEL)
           - 570bc9ebecd92723d2d21500f4be314c  # Remaster
@@ -115,17 +106,9 @@ radarr:
       # Misc
           - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
-        quality_profiles:
-          - name: SQP-3
-
-      - trash_ids:
           - 2899d84dc9372de3408e6d8cc18e9666  # x264
-        quality_profiles:
-          - name: SQP-3
-            score: -10000
 
       # Unwanted
-      - trash_ids:
           - ed38b889b31be83fda192888e2286d83  # BR-DISK
           - 90a6f9a284dff5103f6346090e6280c8  # LQ
           - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
@@ -145,38 +128,22 @@ radarr:
           # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
           # - f537cf427b64c38c8e36298f657e4828  # Scene
           # - 0a3f082873eb454bde444150b70253cc  # Extras
-        quality_profiles:
-          - name: SQP-3
 
       # Resolution
-      - trash_ids:
           - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p
-        quality_profiles:
-          - name: SQP-3
-
-      - trash_ids:
           - fb392fb0d61a010ae38e49ceaa24a1ef  # 2160p
-        quality_profiles:
-          - name: SQP-3
-            score: 151
 
       # Streaming Services
-      - trash_ids:
-          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
-          - 2a6039655313bf5dab1e43523b62c374  # MA
-          - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
-        quality_profiles:
-          - name: SQP-3
-
-      - trash_ids:
-          # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
           - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+          - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
           - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 2a6039655313bf5dab1e43523b62c374  # MA
           - 6a061313d22e51e0f25b7cd4dc065233  # MAX
           - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
           - fbca986396c5e695ef7b2def3c755d01  # OViD
@@ -186,4 +153,3 @@ radarr:
           - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: SQP-3
-            score: 0

--- a/radarr/sqp/sqp-4.yml
+++ b/radarr/sqp/sqp-4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-4                                                         #
-# Updated: 2023-08-15                                                                             #
+# Updated: 2023-08-27                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -34,6 +34,7 @@ radarr:
           until_quality: WEB|2160p
           until_score: 10000
         min_format_score: 550
+        score_set: sqp-4
         quality_sort: top
         qualities:
           - name: WEB|2160p
@@ -49,8 +50,8 @@ radarr:
 # and applies them and their scores to Quality Profiles
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#custom-format-settings
     custom_formats:
-      # Audio
       - trash_ids:
+      # Audio
           - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
           - 2f22d89048b01681dde8afe203bf2e95  # DTS X
           - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
@@ -77,20 +78,10 @@ radarr:
           - 2a4d9069cc1fe3242ff9bdaebed239bb  # HDR (undefined)
           - 08d6d8834ad9ec87b1dc7ec8148e7a1f  # PQ
           - 9364dd386c9b4a1100dde8264690add7  # HLG
-        quality_profiles:
-          - name: SQP-4
-
-      - trash_ids:
-          # DV (WEBDL)
+          # Uncomment the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
-        quality_profiles:
-          - name: SQP-4
-            # If you and all of your users have a setup that fully supports DV, then uncomment the
-            # next line to override the default DV (WEBDL) score of -10000
-            # score: 0
 
       # Movie Versions
-      - trash_ids:
           - 0f12c086e289cf966fa5948eac571f44  # Hybrid
           - f700d29429c023a5734505e77daeaea7  # DV (FEL)
           - 570bc9ebecd92723d2d21500f4be314c  # Remaster
@@ -114,17 +105,9 @@ radarr:
       # Misc
           - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
-        quality_profiles:
-          - name: SQP-4
-
-      - trash_ids:
           - 2899d84dc9372de3408e6d8cc18e9666  # x264
-        quality_profiles:
-          - name: SQP-4
-            score: -10000
 
       # Unwanted
-      - trash_ids:
           - ed38b889b31be83fda192888e2286d83  # BR-DISK
           - 90a6f9a284dff5103f6346090e6280c8  # LQ
           - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
@@ -144,38 +127,22 @@ radarr:
           # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
           # - f537cf427b64c38c8e36298f657e4828  # Scene
           # - 0a3f082873eb454bde444150b70253cc  # Extras
-        quality_profiles:
-          - name: SQP-4
 
       # Resolution
-      - trash_ids:
           - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p
-        quality_profiles:
-          - name: SQP-4
-
-      - trash_ids:
           - fb392fb0d61a010ae38e49ceaa24a1ef  # 2160p
-        quality_profiles:
-          - name: SQP-4
-            score: 151
 
       # Streaming Services
-      - trash_ids:
-          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
-          - 2a6039655313bf5dab1e43523b62c374  # MA
-          - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
-        quality_profiles:
-          - name: SQP-4
-
-      - trash_ids:
-          # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
           - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+          - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
           - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 2a6039655313bf5dab1e43523b62c374  # MA
           - 6a061313d22e51e0f25b7cd4dc065233  # MAX
           - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
           - fbca986396c5e695ef7b2def3c755d01  # OViD
@@ -185,4 +152,3 @@ radarr:
           - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: SQP-4
-            score: 0

--- a/radarr/sqp/sqp-5.yml
+++ b/radarr/sqp/sqp-5.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-5                                                         #
-# Updated: 2023-08-15                                                                             #
+# Updated: 2023-08-27                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -34,6 +34,7 @@ radarr:
           until_quality: WEB|Bluray|2160p
           until_score: 10000
         min_format_score: 550
+        score_set: sqp-5
         quality_sort: top
         qualities:
           - name: WEB|Bluray|2160p
@@ -50,8 +51,8 @@ radarr:
 # and applies them and their scores to Quality Profiles
 # Documentation: https://recyclarr.dev/wiki/yaml/config-reference/#custom-format-settings
     custom_formats:
-      # Audio
       - trash_ids:
+      # Audio
           - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
           - 2f22d89048b01681dde8afe203bf2e95  # DTS X
           - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
@@ -78,20 +79,10 @@ radarr:
           - 2a4d9069cc1fe3242ff9bdaebed239bb  # HDR (undefined)
           - 08d6d8834ad9ec87b1dc7ec8148e7a1f  # PQ
           - 9364dd386c9b4a1100dde8264690add7  # HLG
-        quality_profiles:
-          - name: SQP-5
-
-      - trash_ids:
-          # DV (WEBDL)
+          # Uncomment the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
-        quality_profiles:
-          - name: SQP-5
-            # If you and all of your users have a setup that fully supports DV, then uncomment the
-            # next line to override the default DV (WEBDL) score of -10000
-            # score: 0
 
       # Movie Versions
-      - trash_ids:
           - 0f12c086e289cf966fa5948eac571f44  # Hybrid
           - f700d29429c023a5734505e77daeaea7  # DV (FEL)
           - 570bc9ebecd92723d2d21500f4be314c  # Remaster
@@ -108,28 +99,9 @@ radarr:
           - 3a3ff47579026e76d6504ebea39390de  # Remux Tier 01
           - 9f98181fe5a3fbeb0cc29340da2a468a  # Remux Tier 02
           - 8baaf0b3142bf4d94c42a724f034e27a  # Remux Tier 03
-        quality_profiles:
-          - name: SQP-5
-
-      - trash_ids:
           - 4d74ac4c4db0b64bff6ce0cffef99bf0  # UHD Bluray Tier 01
-        quality_profiles:
-          - name: SQP-5
-            score: 2300
-
-      - trash_ids:
           - a58f517a70193f8e578056642178419d  # UHD Bluray Tier 02
-        quality_profiles:
-          - name: SQP-5
-            score: 2200
-
-      - trash_ids:
           - e71939fae578037e7aed3ee219bbe7c1  # UHD Bluray Tier 03
-        quality_profiles:
-          - name: SQP-5
-            score: 2100
-
-      - trash_ids:
           - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
           - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
           - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
@@ -137,17 +109,9 @@ radarr:
       # Misc
           - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
-        quality_profiles:
-          - name: SQP-5
-
-      - trash_ids:
           - 2899d84dc9372de3408e6d8cc18e9666  # x264
-        quality_profiles:
-          - name: SQP-5
-            score: -10000
 
       # Unwanted
-      - trash_ids:
           - ed38b889b31be83fda192888e2286d83  # BR-DISK
           - 90a6f9a284dff5103f6346090e6280c8  # LQ
           - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
@@ -167,38 +131,22 @@ radarr:
           # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
           # - f537cf427b64c38c8e36298f657e4828  # Scene
           # - 0a3f082873eb454bde444150b70253cc  # Extras
-        quality_profiles:
-          - name: SQP-5
 
       # Resolution
-      - trash_ids:
           - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p
-        quality_profiles:
-          - name: SQP-5
-
-      - trash_ids:
           - fb392fb0d61a010ae38e49ceaa24a1ef  # 2160p
-        quality_profiles:
-          - name: SQP-5
-            score: 151
 
       # Streaming Services
-      - trash_ids:
-          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
-          - 2a6039655313bf5dab1e43523b62c374  # MA
-          - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
-        quality_profiles:
-          - name: SQP-5
-
-      - trash_ids:
-          # Streaming Services
           - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
           - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
           - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+          - 16622a6911d1ab5d5b8b713d5b0036d4  # CRiT
           - 84272245b2988854bfb76a16e60baea5  # DSNP
           - 509e5f41146e278f9eab1ddaceb34515  # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
           - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 2a6039655313bf5dab1e43523b62c374  # MA
           - 6a061313d22e51e0f25b7cd4dc065233  # MAX
           - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
           - fbca986396c5e695ef7b2def3c755d01  # OViD
@@ -208,4 +156,3 @@ radarr:
           - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: SQP-5
-            score: 0


### PR DESCRIPTION
- Add `score_sets` variable to SQP config files
- Remove manual custom scores from SQP config files