### PR TITLE
chore: :wrench: Update for score_set flag

### DIFF
--- a/radarr/templates/anime-radarr.yml
+++ b/radarr/templates/anime-radarr.yml
@@ -34,6 +34,7 @@ radarr:
           until_quality: Remux-1080p
           until_score: 10000
         min_format_score: 100
+        score_set: anime-radarr
         quality_sort: top
         qualities:
           - name: Remux-1080p
@@ -87,84 +88,38 @@ radarr:
           - 3df5e6dfef4b09bb6002f732bed5b774  # v2
           - db92c27ba606996b146b57fbe6d09186  # v3
           - d4e5e842fad129a3c097bdb2d20d31a0  # v4
+          - 06b6542a47037d1e33b15aa3677c2365  # Anime Raws
+          - a5d148168c4506b55cf53984107c396e  # 10bit
+          - 9172b2f683f6223e3a1846427b417a3d  # VOSTFR
+          - b23eae459cc960816f2d6ba84af45055  # Dubs Only
           # Anime Streaming Services
           - 60f6d50cbd3cfc3e9a8c00e3a30c3114  # VRV
-        quality_profiles:
-          - name: Remux-1080p - Anime
-
-      # Custom Scoring
-      # Anime CF/Scoring
-      - trash_ids:
-          - 9172b2f683f6223e3a1846427b417a3d  # VOSTFR
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: -10000
-
-      # Main Guide Remux Tier Scoring
-      - trash_ids:
+          # Main Guide Remux Tier Scoring
           - 3a3ff47579026e76d6504ebea39390de  # Remux Tier 01
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 1050  # required as this differs from the standard scoring
-
-      - trash_ids:
           - 9f98181fe5a3fbeb0cc29340da2a468a  # Remux Tier 02
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 1000  # required as this differs from the standard scoring
-
-      - trash_ids:
           - 8baaf0b3142bf4d94c42a724f034e27a  # Remux Tier 03
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 950  # required as this differs from the standard scoring
-
-      # Main Guide WEB Tier Scoring
-      - trash_ids:
+          # Main Guide WEB Tier Scoring
           - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 350  # required as this differs from the standard scoring
-
-      - trash_ids:
           - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 300  # required as this differs from the standard scoring
-
-      - trash_ids:
           - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 250  # required as this differs from the standard scoring
+          - name: Remux-1080p - Anime!
 
+      # Custom Scoring
       # Adjustable scoring section
-      - trash_ids:
-          - 06b6542a47037d1e33b15aa3677c2365  # Anime Raws
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: -10000  # adjust as desired
-
       - trash_ids:
           - 064af5f084a0a24458cc8ecd3220f93f  # Uncensored
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 0  # adjust as desired
-
-      - trash_ids:
-          - a5d148168c4506b55cf53984107c396e  # 10bit
-        quality_profiles:
-          - name: Remux-1080p - Anime
+            score: 101
+          - name: Remux-1080p - Anime!
             score: 0  # adjust as desired
 
       - trash_ids:
           - 4a3b087eea2ce012fcc1ce319259a3be  # Anime Dual Audio
         quality_profiles:
           - name: Remux-1080p - Anime
+            score: 10
+          - name: Remux-1080p - Anime!
             score: 0  # adjust as desired
-
-      - trash_ids:
-          - b23eae459cc960816f2d6ba84af45055  # Dubs Only
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: -10000  # adjust as desired

--- a/radarr/templates/anime-radarr.yml
+++ b/radarr/templates/anime-radarr.yml
@@ -104,7 +104,6 @@ radarr:
           - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
         quality_profiles:
           - name: Remux-1080p - Anime
-          - name: Remux-1080p - Anime!
 
       # Custom Scoring
       # Adjustable scoring section
@@ -112,14 +111,10 @@ radarr:
           - 064af5f084a0a24458cc8ecd3220f93f  # Uncensored
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 101
-          - name: Remux-1080p - Anime!
-            score: 0  # adjust as desired
+            score: 0  # Adjust scoring as desired
 
       - trash_ids:
           - 4a3b087eea2ce012fcc1ce319259a3be  # Anime Dual Audio
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 10
-          - name: Remux-1080p - Anime!
-            score: 0  # adjust as desired
+            score: 0  # Adjust scoring as desired

--- a/sonarr/templates/anime-sonarr-v4.yml
+++ b/sonarr/templates/anime-sonarr-v4.yml
@@ -35,6 +35,7 @@ sonarr:
           until_quality: Bluray-1080p
           until_score: 10000
         min_format_score: 100
+        score_set: anime-sonarr
         quality_sort: top
         qualities:
           - name: Bluray-1080p
@@ -83,104 +84,41 @@ sonarr:
           - 29c2a13d091144f63307e4a8ce963a39  # Anime Web Tier 05 (FanSubs)
           - dc262f88d74c651b12e9d90b39f6c753  # Anime Web Tier 06 (FanSubs)
           - e3515e519f3b1360cbfc17651944354c  # Anime LQ Groups
+          - b4a1b3d705159cdca36d71e57ca86871  # Anime Raws
+          - 9c14d194486c4014d422adc64092d794  # Dubs Only
           - d2d7b8a9d39413da5f44054080e028a3  # v0
           - 273bd326df95955e1b6c26527d1df89b  # v1
           - 228b8ee9aa0a609463efca874524a6b8  # v2
           - 0e5833d3af2cc5fa96a0c29cd4477feb  # v3
           - 4fc15eeb8f2f9a749f918217d4234ad8  # v4
+          - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+          - 07a32f77690263bb9fda1842db7e273f  # VOSTFR
+          - b2550eb333d27b75833e25b8c2557b38  # 10bit
           # Anime Streaming Services
           - 3e0b26604165f463f3e8e192261e7284  # CR
           - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
           - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
+          - 89358767a60cc28783cdc3d0be9388a4  # DSNP
+          - d34870697c9db575f17700212167be23  # NF
+          - d660701077794679fd59e8bdf4ce3a29  # AMZN
+          - d54cd2bf1326287275b56bccedb72ee2  # ADN
+          - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
+          - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
+          - 570b03b3145a25011bf073274a407259  # HIDIVE
+          # Main Guide Remux Tier Scoring
+          - 9965a052eb87b0d10313b1cea89eb451  # Remux Tier 01
+          - 8a1d0c3d7497e741736761a1da866a2e  # Remux Tier 02
+          # Main Guide WEB Tier Scoring
+          - e6258996055b9fbab7e9cb2f75819294  # WEB Tier 01
+          - 58790d4e2fdcd9733aa7ae68ba2bb503  # WEB Tier 02
+          - d84935abd3f8556dcd51d4f27e22d0a6  # WEB Tier 03
         quality_profiles:
           - name: Remux-1080p - Anime
 
       # Custom scoring
-      # Anime Streaming Services
-      - trash_ids:
-          - 89358767a60cc28783cdc3d0be9388a4  # DSNP
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 5  # required as this differs from the standard scoring
-
-      - trash_ids:
-          - d34870697c9db575f17700212167be23  # NF
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 3  # required as this differs from the standard scoring
-
-      - trash_ids:
-          - d660701077794679fd59e8bdf4ce3a29  # AMZN
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 3  # required as this differs from the standard scoring
-
-      - trash_ids:
-          - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 1  # required as this differs from the standard scoring
-
-      - trash_ids:
-          - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-          - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-          - 570b03b3145a25011bf073274a407259  # HIDIVE
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 0  # no score in guide
-
-      # Anime CF/Scoring
-      - trash_ids:
-          - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-          - 07a32f77690263bb9fda1842db7e273f  # VOSTFR
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: -10000
-
-      # Main Guide Remux Tier Scoring
-      - trash_ids:
-          - 9965a052eb87b0d10313b1cea89eb451  # Remux Tier 01
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 1050  # required as this differs from the standard scoring
-      - trash_ids:
-          - 8a1d0c3d7497e741736761a1da866a2e  # Remux Tier 02
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 1000  # required as this differs from the standard scoring
-
-      # Main Guide WEB Tier Scoring
-      - trash_ids:
-          - e6258996055b9fbab7e9cb2f75819294  # WEB Tier 01
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 450  # required as this differs from the standard scoring
-      - trash_ids:
-          - 58790d4e2fdcd9733aa7ae68ba2bb503  # WEB Tier 02
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 400  # required as this differs from the standard scoring
-      - trash_ids:
-          - d84935abd3f8556dcd51d4f27e22d0a6  # WEB Tier 03
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 350  # required as this differs from the standard scoring
-
       # Adjustable scoring section
       - trash_ids:
-          - b4a1b3d705159cdca36d71e57ca86871  # Anime Raws
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: -10000  # Adjust scoring as desired
-
-      - trash_ids:
           - 026d5aadd1a6b4e550b134cb6c72b3ca  # Uncensored
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: 0  # Adjust scoring as desired
-
-      - trash_ids:
-          - b2550eb333d27b75833e25b8c2557b38  # 10bit
         quality_profiles:
           - name: Remux-1080p - Anime
             score: 0  # Adjust scoring as desired
@@ -190,9 +128,3 @@ sonarr:
         quality_profiles:
           - name: Remux-1080p - Anime
             score: 0  # Adjust scoring as desired
-
-      - trash_ids:
-          - 9c14d194486c4014d422adc64092d794  # Dubs Only
-        quality_profiles:
-          - name: Remux-1080p - Anime
-            score: -10000  # Adjust scoring as desired


### PR DESCRIPTION
Updated to include `score_set` flag introduced in latest version of recyclarr.
Combined trash_id's in line with how a score_set is handled.
Cleaned up Adjustable section to be in line with the originating guide.