### PR TITLE
Add anime-radarr to includes.json

### DIFF
--- a/includes.json
+++ b/includes.json
@@ -17,6 +17,10 @@
       "id": "remux-web-2160p"
     },
     {
+      "template": "radarr/includes/anime-radarr.yml",
+      "id": "anime-radarr"
+    },
+    {
       "template": "radarr/includes/sqp/sqp-1-1080p.yml",
       "id": "sqp-1-1080p"
     },


### PR DESCRIPTION
anime-radarr was missing from [includes.json](https://github.com/recyclarr/config-templates/blob/master/includes.json) which throws an unable to find template error.