### PR TITLE
Move SQP 2-5 Optionals

### DIFF
--- a/radarr/includes/sqp/sqp-2.yml
+++ b/radarr/includes/sqp/sqp-2.yml
@@ -55,7 +55,6 @@ custom_formats:
 
   # Movie Versions
       - 0f12c086e289cf966fa5948eac571f44  # Hybrid
-      - f700d29429c023a5734505e77daeaea7  # DV (FEL)
       - 570bc9ebecd92723d2d21500f4be314c  # Remaster
       - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
       - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
@@ -83,10 +82,8 @@ custom_formats:
   # Unwanted
       - ed38b889b31be83fda192888e2286d83  # BR-DISK
       - 90a6f9a284dff5103f6346090e6280c8  # LQ
-      - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
       - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
       - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
-      - 9c38ebb7384dada637be8899efa68e6f  # SDR
 
   # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p

--- a/radarr/includes/sqp/sqp-3.yml
+++ b/radarr/includes/sqp/sqp-3.yml
@@ -54,7 +54,6 @@ custom_formats:
 
   # Movie Versions
       - 0f12c086e289cf966fa5948eac571f44  # Hybrid
-      - f700d29429c023a5734505e77daeaea7  # DV (FEL)
       - 570bc9ebecd92723d2d21500f4be314c  # Remaster
       - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
       - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
@@ -79,10 +78,8 @@ custom_formats:
   # Unwanted
       - ed38b889b31be83fda192888e2286d83  # BR-DISK
       - 90a6f9a284dff5103f6346090e6280c8  # LQ
-      - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
       - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
       - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
-      - 9c38ebb7384dada637be8899efa68e6f  # SDR
 
   # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p

--- a/radarr/includes/sqp/sqp-4.yml
+++ b/radarr/includes/sqp/sqp-4.yml
@@ -53,7 +53,6 @@ custom_formats:
 
   # Movie Versions
       - 0f12c086e289cf966fa5948eac571f44  # Hybrid
-      - f700d29429c023a5734505e77daeaea7  # DV (FEL)
       - 570bc9ebecd92723d2d21500f4be314c  # Remaster
       - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
       - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
@@ -78,10 +77,8 @@ custom_formats:
   # Unwanted
       - ed38b889b31be83fda192888e2286d83  # BR-DISK
       - 90a6f9a284dff5103f6346090e6280c8  # LQ
-      - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
       - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
       - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
-      - 9c38ebb7384dada637be8899efa68e6f  # SDR
 
   # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p

--- a/radarr/includes/sqp/sqp-5.yml
+++ b/radarr/includes/sqp/sqp-5.yml
@@ -54,7 +54,6 @@ custom_formats:
 
   # Movie Versions
       - 0f12c086e289cf966fa5948eac571f44  # Hybrid
-      - f700d29429c023a5734505e77daeaea7  # DV (FEL)
       - 570bc9ebecd92723d2d21500f4be314c  # Remaster
       - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
       - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
@@ -82,10 +81,8 @@ custom_formats:
   # Unwanted
       - ed38b889b31be83fda192888e2286d83  # BR-DISK
       - 90a6f9a284dff5103f6346090e6280c8  # LQ
-      - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
       - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
       - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
-      - 9c38ebb7384dada637be8899efa68e6f  # SDR
 
   # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -1,15 +1,13 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-2                                                         #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-09-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
 # https://recyclarr.dev/wiki/yaml/config-examples/#merge-single-instance                          #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 radarr:
   sqp-2:
     base_url: Put your Radarr URL here
@@ -18,12 +16,7 @@ radarr:
     include:
       - template: sqp-2
 
-# Custom Formats
-# This section creates and/or updates Custom Formats in your Radarr instance,
-# and applies them and their scores to Quality Profiles
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
-
-# You must comment out lines 27, 28, 49 and 50 if you disable all the custom formats below
+# Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
       - trash_ids:
       # HDR Formats
@@ -33,6 +26,12 @@ radarr:
       # IMAX-E
           # Uncomment the next line if you prefer IMAX Enhanced releases
           # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+
+      # x265
+          # Use ONE of the following two options to determine whether all 1080p x265 releases are
+          # blocked, or whether to permit those with DV/HDR
+          - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+          # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
 
       # Optional
           # Uncomment any of the following optional custom formats if you want them to be added to
@@ -46,5 +45,7 @@ radarr:
           # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
           # - f537cf427b64c38c8e36298f657e4828  # Scene
           # - 0a3f082873eb454bde444150b70253cc  # Extras
+          - 9c38ebb7384dada637be8899efa68e6f  # SDR
+          - f700d29429c023a5734505e77daeaea7  # DV (FEL)
         quality_profiles:
           - name: SQP-2

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -1,15 +1,13 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-3                                                         #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-09-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
 # https://recyclarr.dev/wiki/yaml/config-examples/#merge-single-instance                          #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 radarr:
   sqp-3:
     base_url: Put your Radarr URL here
@@ -18,12 +16,7 @@ radarr:
     include:
       - template: sqp-3
 
-# Custom Formats
-# This section creates and/or updates Custom Formats in your Radarr instance,
-# and applies them and their scores to Quality Profiles
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
-
-# You must comment out lines 27, 28, 49 and 50 if you disable all the custom formats below
+# Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
       - trash_ids:
       # HDR Formats
@@ -33,6 +26,12 @@ radarr:
       # IMAX-E
           # Uncomment the next line if you prefer IMAX Enhanced releases
           # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+
+      # x265
+          # Use ONE of the following two options to determine whether all 1080p x265 releases are
+          # blocked, or whether to permit those with DV/HDR
+          - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+          # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
 
       # Optional
           # Uncomment any of the following optional custom formats if you want them to be added to
@@ -46,5 +45,7 @@ radarr:
           # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
           # - f537cf427b64c38c8e36298f657e4828  # Scene
           # - 0a3f082873eb454bde444150b70253cc  # Extras
+          - 9c38ebb7384dada637be8899efa68e6f  # SDR
+          - f700d29429c023a5734505e77daeaea7  # DV (FEL)
         quality_profiles:
           - name: SQP-3

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -1,15 +1,13 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-4                                                         #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-09-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
 # https://recyclarr.dev/wiki/yaml/config-examples/#merge-single-instance                          #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 radarr:
   sqp-4:
     base_url: Put your Radarr URL here
@@ -18,12 +16,7 @@ radarr:
     include:
       - template: sqp-4
 
-# Custom Formats
-# This section creates and/or updates Custom Formats in your Radarr instance,
-# and applies them and their scores to Quality Profiles
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
-
-# You must comment out lines 27, 28, 49 and 50 if you disable all the custom formats below
+# Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
       - trash_ids:
       # HDR Formats
@@ -33,6 +26,12 @@ radarr:
       # IMAX-E
           # Uncomment the next line if you prefer IMAX Enhanced releases
           # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+
+      # x265
+          # Use ONE of the following two options to determine whether all 1080p x265 releases are
+          # blocked, or whether to permit those with DV/HDR
+          - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+          # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
 
       # Optional
           # Uncomment any of the following optional custom formats if you want them to be added to
@@ -46,5 +45,7 @@ radarr:
           # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
           # - f537cf427b64c38c8e36298f657e4828  # Scene
           # - 0a3f082873eb454bde444150b70253cc  # Extras
+          - 9c38ebb7384dada637be8899efa68e6f  # SDR
+          - f700d29429c023a5734505e77daeaea7  # DV (FEL)
         quality_profiles:
           - name: SQP-4

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -1,15 +1,13 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-5                                                         #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-09-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
 # https://recyclarr.dev/wiki/yaml/config-examples/#merge-single-instance                          #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 radarr:
   sqp-5:
     base_url: Put your Radarr URL here
@@ -18,12 +16,7 @@ radarr:
     include:
       - template: sqp-5
 
-# Custom Formats
-# This section creates and/or updates Custom Formats in your Radarr instance,
-# and applies them and their scores to Quality Profiles
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
-
-# You must comment out lines 27, 28, 49 and 50 if you disable all the custom formats below
+# Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
       - trash_ids:
       # HDR Formats
@@ -33,6 +26,12 @@ radarr:
       # IMAX-E
           # Uncomment the next line if you prefer IMAX Enhanced releases
           # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+
+      # x265
+          # Use ONE of the following two options to determine whether all 1080p x265 releases are
+          # blocked, or whether to permit those with DV/HDR
+          - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+          # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
 
       # Optional
           # Uncomment any of the following optional custom formats if you want them to be added to
@@ -46,5 +45,7 @@ radarr:
           # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
           # - f537cf427b64c38c8e36298f657e4828  # Scene
           # - 0a3f082873eb454bde444150b70253cc  # Extras
+          - 9c38ebb7384dada637be8899efa68e6f  # SDR
+          - f700d29429c023a5734505e77daeaea7  # DV (FEL)
         quality_profiles:
           - name: SQP-5


### PR DESCRIPTION
- relocate golden rule choice, and DV (FEL) and SDR optionals to the templates instead of the include