### PR TITLE
feat: Simplify Templates, Update Includes and Relocate Optionals

### DIFF
--- a/radarr/includes/hd-bluray-web.yml
+++ b/radarr/includes/hd-bluray-web.yml
@@ -48,6 +48,7 @@ custom_formats:
       - 90a6f9a284dff5103f6346090e6280c8  # LQ
       - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
       - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+      - 0a3f082873eb454bde444150b70253cc  # Extras
 
       # Streaming Services
       - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE

--- a/radarr/includes/remux-web-1080p.yml
+++ b/radarr/includes/remux-web-1080p.yml
@@ -48,6 +48,7 @@ custom_formats:
       - 90a6f9a284dff5103f6346090e6280c8  # LQ
       - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
       - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+      - 0a3f082873eb454bde444150b70253cc  # Extras
 
       # Streaming Services
       - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE

--- a/radarr/includes/remux-web-2160p.yml
+++ b/radarr/includes/remux-web-2160p.yml
@@ -62,7 +62,7 @@ custom_formats:
       - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
       - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
       - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
-      - 9c38ebb7384dada637be8899efa68e6f  # SDR
+      - 0a3f082873eb454bde444150b70253cc  # Extras
 
       # Streaming Services
       - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE

--- a/radarr/includes/sqp/sqp-1-2160p-shared.yml
+++ b/radarr/includes/sqp/sqp-1-2160p-shared.yml
@@ -58,7 +58,6 @@ custom_formats:
       - 90a6f9a284dff5103f6346090e6280c8  # LQ
       - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
       - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
-      - 9c38ebb7384dada637be8899efa68e6f  # SDR
 
   # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p

--- a/radarr/includes/uhd-bluray-web.yml
+++ b/radarr/includes/uhd-bluray-web.yml
@@ -60,7 +60,7 @@ custom_formats:
       - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
       - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
       - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
-      - 9c38ebb7384dada637be8899efa68e6f  # SDR
+      - 0a3f082873eb454bde444150b70253cc  # Extras
 
       # Streaming Services
       - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE

--- a/radarr/templates/anime-radarr.yml
+++ b/radarr/templates/anime-radarr.yml
@@ -1,15 +1,13 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Anime Radarr                                                  #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-09-24                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
 # https://recyclarr.dev/wiki/yaml/config-examples/#merge-single-instance                          #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 radarr:
   anime-radarr:
     base_url: Put your Radarr URL here
@@ -18,10 +16,7 @@ radarr:
     include:
       - template: anime-radarr
 
-# Custom Formats
-# This section creates and/or updates Custom Formats in your Radarr instance,
-# and applies them and their scores to Quality Profiles
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
+# Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
       - trash_ids:
           - 064af5f084a0a24458cc8ecd3220f93f  # Uncensored

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -1,15 +1,13 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB                                               #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-09-24                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
 # https://recyclarr.dev/wiki/yaml/config-examples/#merge-single-instance                          #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 radarr:
   hd-bluray-web:
     base_url: Put your Radarr URL here

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -1,15 +1,13 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Remux + WEB 1080p                                             #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-09-24                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
 # https://recyclarr.dev/wiki/yaml/config-examples/#merge-single-instance                          #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 radarr:
   remux-web-1080p:
     base_url: Put your Radarr URL here
@@ -18,14 +16,10 @@ radarr:
     include:
       - template: remux-web-1080p
 
-# Custom Formats
-# This section creates and/or updates Custom Formats in your Radarr instance,
-# and applies them and their scores to Quality Profiles
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
-
-# Audio - Uncomment the next section if you are using the Advanced Audio Formats
-    # custom_formats:
-      # - trash_ids:
+# Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
+    custom_formats:
+      - trash_ids:
+      # Audio - Uncomment the next section if you are using the Advanced Audio Formats
           # - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
           # - 2f22d89048b01681dde8afe203bf2e95  # DTS X
           # - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
@@ -40,5 +34,5 @@ radarr:
           # - 1c1a4c5e823891c75bc50380a6866f73  # DTS
           # - 240770601cc226190c367ef59aba7463  # AAC
           # - c2998bd0d90ed5621d8df281e839436e  # DD
-        # quality_profiles:
-          # - name: Remux + WEB 1080p
+        quality_profiles:
+          - name: Remux + WEB 1080p

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -7,9 +7,7 @@
 # https://recyclarr.dev/wiki/yaml/config-examples/#merge-single-instance                          #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 radarr:
   remux-web-2160p:
     base_url: Put your Radarr URL here
@@ -18,12 +16,8 @@ radarr:
     include:
       - template: remux-web-2160p
 
-# Custom Formats
-# This section creates and/or updates Custom Formats in your Radarr instance,
-# and applies them and their scores to Quality Profiles
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
+# Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
 
-# You must comment out lines 27, 28, 50 and 51 if you disable all the custom formats below
     custom_formats:
       - trash_ids:
       # Audio - Uncomment the next section if you are using the Advanced Audio Formats
@@ -47,5 +41,8 @@ radarr:
           - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
           # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
           # - b17886cb4158d9fea189859409975758  # HDR10Plus Boost
+
+      # Optional
+          - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
         quality_profiles:
           - name: Remux + WEB 2160p

--- a/radarr/templates/sqp/sqp-1-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-1080p.yml
@@ -1,15 +1,13 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (1080p)                                                 #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-09-24                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
 # https://recyclarr.dev/wiki/yaml/config-examples/#merge-single-instance                          #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 radarr:
   sqp-1-1080p:
     base_url: Put your Radarr URL here
@@ -23,14 +21,9 @@ radarr:
     include:
       - template: sqp-1-1080p
 
-# Custom Formats
-# This section creates and/or updates Custom Formats in your Radarr instance,
-# and applies them and their scores to Quality Profiles
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
-
-# You must uncomment lines 27, 28, 41 and 42 if you enable any custom formats below
-    # custom_formats:
-      # - trash_ids:
+# Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
+    custom_formats:
+      - trash_ids:
       # IMAX-E - Uncomment the next line if you prefer WEBDL with IMAX Enhanced to BHDStudio
           # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
 
@@ -43,5 +36,5 @@ radarr:
           # - f537cf427b64c38c8e36298f657e4828  # Scene
           # - 0a3f082873eb454bde444150b70253cc  # Extras
           # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
-        # quality_profiles:
-          # - name: SQP-1 (1080p)
+        quality_profiles:
+          - name: SQP-1 (1080p)

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -1,15 +1,13 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (2160p)                                                 #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-09-24                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
 # https://recyclarr.dev/wiki/yaml/config-examples/#merge-single-instance                          #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 radarr:
   sqp-1-2160p:
     base_url: Put your Radarr URL here
@@ -30,10 +28,7 @@ radarr:
       # Do not comment out the next line as it enables this profile's custom formats
       - template: sqp-1-2160p-shared
 
-# Custom Formats
-# This section creates and/or updates Custom Formats in your Radarr instance,
-# and applies them and their scores to Quality Profiles
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
+# Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
       - trash_ids:
       # IMAX-E
@@ -58,6 +53,7 @@ radarr:
           # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
           # - f537cf427b64c38c8e36298f657e4828  # Scene
           # - 0a3f082873eb454bde444150b70253cc  # Extras
+          - 9c38ebb7384dada637be8899efa68e6f  # SDR
           # Comment out the next line if you don't want to block AV1 releases
           - cae4ca30163749b891686f95532519bd  # AV1
         quality_profiles:

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -1,15 +1,13 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB                                              #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-09-24                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
 # https://recyclarr.dev/wiki/yaml/config-examples/#merge-single-instance                          #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 radarr:
   uhd-bluray-web:
     base_url: Put your Radarr URL here
@@ -18,12 +16,8 @@ radarr:
     include:
       - template: uhd-bluray-web
 
-# Custom Formats
-# This section creates and/or updates Custom Formats in your Radarr instance,
-# and applies them and their scores to Quality Profiles
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
+# Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
 
-# You must comment out lines 27, 28, 50 and 51 if you disable all the custom formats below
     custom_formats:
       - trash_ids:
       # Audio - Uncomment the next section if you are using the Advanced Audio Formats
@@ -47,5 +41,8 @@ radarr:
           - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
           # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
           # - b17886cb4158d9fea189859409975758  # HDR10Plus Boost
+
+      # Optional
+          - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
         quality_profiles:
           - name: UHD Bluray + WEB

--- a/sonarr/includes/web-2160p-v4.yml
+++ b/sonarr/includes/web-2160p-v4.yml
@@ -36,7 +36,6 @@ custom_formats:
       - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
       - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
       - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-      - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
 
       # Misc
       - ec8fa7296b64e8cd390a1600981f3923  # Repack/Proper

--- a/sonarr/templates/anime-sonarr-v4.yml
+++ b/sonarr/templates/anime-sonarr-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Anime Sonarr                                                  #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-09-24                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -8,9 +8,7 @@
 # This config file is for use with Sonarr V4 only                                                 #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 sonarr:
   anime-sonarr-v4:
     base_url: Put your Sonarr URL here
@@ -19,10 +17,7 @@ sonarr:
     include:
       - template: anime-sonarr-v4
 
-# Custom Formats
-# This section creates and/or updates Custom Formats in your Sonarr instance,
-# and applies them and their scores to Quality Profiles
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
+# Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
       - trash_ids:
           - 026d5aadd1a6b4e550b134cb6c72b3ca  # Uncensored

--- a/sonarr/templates/web-1080p-v4.yml
+++ b/sonarr/templates/web-1080p-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: WEB-1080p (V4)                                                #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-09-24                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -8,9 +8,7 @@
 # This config file is for use with Sonarr V4 only                                                 #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 sonarr:
   web-1080p-v4:
     base_url: Put your Sonarr URL here

--- a/sonarr/templates/web-2160p-v4.yml
+++ b/sonarr/templates/web-2160p-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: WEB-2160p (V4)                                                #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-09-24                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -8,9 +8,7 @@
 # This config file is for use with Sonarr V4 only                                                 #
 ###################################################################################################
 
-# Instance Definition
-# This section defines your instance type, name, and authentication
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/basic/
+# Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 sonarr:
   web-2160p-v4:
     base_url: Put your Sonarr URL here
@@ -19,12 +17,7 @@ sonarr:
     include:
       - template: web-2160p-v4
 
-# Custom Formats
-# This section creates and/or updates Custom Formats in your Sonarr instance,
-# and applies them and their scores to Quality Profiles
-# Documentation: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
-
-# You must comment out lines 28, 29, 35 and 36 if you disable all the custom formats below
+# Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
       - trash_ids:
       # HDR Formats
@@ -32,5 +25,8 @@ sonarr:
           - 9b27ab6498ec0f31a3353992e19434ca  # DV (WEBDL)
           # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
           # - 0dad0a507451acddd754fe6dc3a7f5e7  # HDR10Plus Boost
+
+      # Optional
+          - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
         quality_profiles:
           - name: WEB-2160p


### PR DESCRIPTION
- Update templates to enable `custom_formats` section by default, as Recyclarr now supports empty sections
- Move `SDR` optional out of all includes and into templates
- Add `Extras` CF to all includes