### PR TITLE
fix(Templates): Fix incorrect trash_id for SDR Custom Format

### DIFF
--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -43,6 +43,6 @@ radarr:
           # - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
 
       # Optional
-          - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
+          - 9c38ebb7384dada637be8899efa68e6f # SDR
         quality_profiles:
           - name: Remux + WEB 2160p

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -43,6 +43,6 @@ radarr:
           # - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
 
       # Optional
-          - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
+          - 9c38ebb7384dada637be8899efa68e6f # SDR
         quality_profiles:
           - name: UHD Bluray + WEB


### PR DESCRIPTION
- Replaced the incorrect Radarr `trash_id` for the `SDR` custom format in the Remux + WEB 2160p and UHD Bluray + WEB templates