### PR TITLE
feat: Optional Custom Formats Reconciliation

### DIFF
--- a/radarr/includes/remux-web-2160p.yml
+++ b/radarr/includes/remux-web-2160p.yml
@@ -64,6 +64,9 @@ custom_formats:
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
       - 0a3f082873eb454bde444150b70253cc # Extras
 
+      # Optional UHD
+      - 9c38ebb7384dada637be8899efa68e6f # SDR
+
       # Streaming Services
       - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
       - 16622a6911d1ab5d5b8b713d5b0036d4 # CRiT

--- a/radarr/includes/sqp/sqp-1-2160p-shared.yml
+++ b/radarr/includes/sqp/sqp-1-2160p-shared.yml
@@ -58,6 +58,12 @@ custom_formats:
       - 90a6f9a284dff5103f6346090e6280c8 # LQ
       - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+      - 0a3f082873eb454bde444150b70253cc # Extras
+
+  # Optional
+      - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+      - cae4ca30163749b891686f95532519bd # AV1
+      - 9c38ebb7384dada637be8899efa68e6f # SDR
 
   # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p

--- a/radarr/includes/sqp/sqp-2.yml
+++ b/radarr/includes/sqp/sqp-2.yml
@@ -62,6 +62,7 @@ custom_formats:
       - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
       - 957d0f44b592285f26449575e8b1167e # Special Edition
       - eecf3a857724171f968a66cb5719e152 # IMAX
+      - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
 
   # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
@@ -84,6 +85,11 @@ custom_formats:
       - 90a6f9a284dff5103f6346090e6280c8 # LQ
       - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+      - 0a3f082873eb454bde444150b70253cc # Extras
+
+  # Optional
+      - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+      - 9c38ebb7384dada637be8899efa68e6f # SDR
 
   # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p

--- a/radarr/includes/sqp/sqp-3.yml
+++ b/radarr/includes/sqp/sqp-3.yml
@@ -61,6 +61,7 @@ custom_formats:
       - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
       - 957d0f44b592285f26449575e8b1167e # Special Edition
       - eecf3a857724171f968a66cb5719e152 # IMAX
+      - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
 
   # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
@@ -80,6 +81,11 @@ custom_formats:
       - 90a6f9a284dff5103f6346090e6280c8 # LQ
       - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+      - 0a3f082873eb454bde444150b70253cc # Extras
+
+  # Optional
+      - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+      - 9c38ebb7384dada637be8899efa68e6f # SDR
 
   # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p

--- a/radarr/includes/sqp/sqp-4.yml
+++ b/radarr/includes/sqp/sqp-4.yml
@@ -60,6 +60,7 @@ custom_formats:
       - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
       - 957d0f44b592285f26449575e8b1167e # Special Edition
       - eecf3a857724171f968a66cb5719e152 # IMAX
+      - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
 
   # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
@@ -79,6 +80,11 @@ custom_formats:
       - 90a6f9a284dff5103f6346090e6280c8 # LQ
       - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+      - 0a3f082873eb454bde444150b70253cc # Extras
+
+  # Optional
+      - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+      - 9c38ebb7384dada637be8899efa68e6f # SDR
 
   # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p

--- a/radarr/includes/sqp/sqp-5.yml
+++ b/radarr/includes/sqp/sqp-5.yml
@@ -61,6 +61,7 @@ custom_formats:
       - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
       - 957d0f44b592285f26449575e8b1167e # Special Edition
       - eecf3a857724171f968a66cb5719e152 # IMAX
+      - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
 
   # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
@@ -83,6 +84,11 @@ custom_formats:
       - 90a6f9a284dff5103f6346090e6280c8 # LQ
       - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+      - 0a3f082873eb454bde444150b70253cc # Extras
+
+  # Optional
+      - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+      - 9c38ebb7384dada637be8899efa68e6f # SDR
 
   # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p

--- a/radarr/includes/uhd-bluray-web.yml
+++ b/radarr/includes/uhd-bluray-web.yml
@@ -62,6 +62,9 @@ custom_formats:
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
       - 0a3f082873eb454bde444150b70253cc # Extras
 
+      # Optional UHD
+      - 9c38ebb7384dada637be8899efa68e6f # SDR
+
       # Streaming Services
       - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
       - 16622a6911d1ab5d5b8b713d5b0036d4 # CRiT

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB                                               #
-# Updated: 2023-10-01                                                                             #
+# Updated: 2023-10-03                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB                                               #
-# Updated: 2023-09-24                                                                             #
+# Updated: 2023-10-01                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -15,3 +15,11 @@ radarr:
 
     include:
       - template: hd-bluray-web
+
+    custom_formats:
+      # Movie Versions
+      - trash_ids:
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+        quality_profiles:
+          - name: HD Bluray + WEB
+            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Remux + WEB 1080p                                             #
-# Updated: 2023-09-24                                                                             #
+# Updated: 2023-10-01                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -18,8 +18,9 @@ radarr:
 
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
+      # Audio
       - trash_ids:
-      # Audio - Uncomment the next section if you are using the Advanced Audio Formats
+          # Uncomment the next section to enable Advanced Audio Formats
           # - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
           # - 2f22d89048b01681dde8afe203bf2e95 # DTS X
           # - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
@@ -36,3 +37,10 @@ radarr:
           # - c2998bd0d90ed5621d8df281e839436e # DD
         quality_profiles:
           - name: Remux + WEB 1080p
+
+      # Movie Versions
+      - trash_ids:
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+        quality_profiles:
+          - name: Remux + WEB 1080p
+            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Remux + WEB 1080p                                             #
-# Updated: 2023-10-01                                                                             #
+# Updated: 2023-10-03                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Remux + WEB 2160p                                             #
-# Updated: 2023-10-01                                                                             #
+# Updated: 2023-10-03                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Remux + WEB 2160p                                             #
-# Updated: 2023-09-16                                                                             #
+# Updated: 2023-10-01                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -19,8 +19,9 @@ radarr:
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
 
     custom_formats:
+      # Audio
       - trash_ids:
-      # Audio - Uncomment the next section if you are using the Advanced Audio Formats
+          # Uncomment the next section to enable Advanced Audio Formats
           # - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
           # - 2f22d89048b01681dde8afe203bf2e95 # DTS X
           # - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
@@ -35,14 +36,27 @@ radarr:
           # - 1c1a4c5e823891c75bc50380a6866f73 # DTS
           # - 240770601cc226190c367ef59aba7463 # AAC
           # - c2998bd0d90ed5621d8df281e839436e # DD
+        quality_profiles:
+          - name: Remux + WEB 2160p
 
-      # HDR Formats
+      # Movie Versions
+      - trash_ids:
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+        quality_profiles:
+          - name: Remux + WEB 2160p
+            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
+
+      # Optional
+      - trash_ids:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
           # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
           # - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
+        quality_profiles:
+          - name: Remux + WEB 2160p
 
-      # Optional
+      - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
         quality_profiles:
           - name: Remux + WEB 2160p
+            # score: 0 # Uncomment this line to allow SDR releases

--- a/radarr/templates/sqp/sqp-1-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-1080p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (1080p)                                                 #
-# Updated: 2023-09-24                                                                             #
+# Updated: 2023-10-01                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -23,11 +23,12 @@ radarr:
 
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
+      # Movie Versions
       - trash_ids:
-      # IMAX-E - Uncomment the next line if you prefer WEBDL with IMAX Enhanced to BHDStudio
+      # Uncomment the next line if you prefer WEBDL with IMAX Enhanced to BHDStudio
           # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
 
-# Optional - Uncomment any of the following custom formats if you want them added to your profile
+      # Optional - uncomment any of the following if you want them added to your profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup

--- a/radarr/templates/sqp/sqp-1-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-1080p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (1080p)                                                 #
-# Updated: 2023-10-01                                                                             #
+# Updated: 2023-10-03                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (2160p)                                                 #
-# Updated: 2023-09-24                                                                             #
+# Updated: 2023-10-01                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -30,18 +30,27 @@ radarr:
 
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
+      # Movie Versions
       - trash_ids:
-      # IMAX-E
           # Uncomment the next line if you prefer 1080p/2160p WEBDL with IMAX Enhanced
           # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+        quality_profiles:
+          - name: SQP-1 (2160p)
 
-      # x265
-          # Use ONE of the following two options to determine whether all 1080p x265 releases are
-          # blocked, or whether to permit those with DV/HDR
-          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+      # Unwanted
+      - trash_ids:
+          # Uncomment the next six lines to block all x265 HD releases
+          # - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+        # quality_profiles:
+          # - name: SQP-1 (2160p)
+            # score: 0
+      # - trash_ids:
           # - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+        quality_profiles:
+          - name: SQP-1 (2160p)
 
       # Optional
+      - trash_ids:
           # Uncomment any of the following optional custom formats if you want them to be added to
           # the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
@@ -52,9 +61,17 @@ radarr:
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
           # - f537cf427b64c38c8e36298f657e4828 # Scene
-          # - 0a3f082873eb454bde444150b70253cc # Extras
+        quality_profiles:
+          - name: SQP-1 (2160p)
+
+      - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
-          # Comment out the next line if you don't want to block AV1 releases
+        quality_profiles:
+          - name: SQP-1 (2160p)
+            # score: 0 # Uncomment this line to allow SDR releases
+
+      - trash_ids:
           - cae4ca30163749b891686f95532519bd # AV1
         quality_profiles:
           - name: SQP-1 (2160p)
+            # score: 0 # Uncomment this line to allow AV1 releases

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (2160p)                                                 #
-# Updated: 2023-10-01                                                                             #
+# Updated: 2023-10-03                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -46,20 +46,10 @@ radarr:
 
       # Optional
       - trash_ids:
-          # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
-        quality_profiles:
-          - name: SQP-2
-
-      - trash_ids:
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
-        quality_profiles:
-          - name: SQP-2
-            # score: 0 # Uncomment this line to enable SDR releases
-
-      - trash_ids:
           # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
+          # Comment out the next line if you and all of your users' setups are fully DV compatible
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
           # Uncomment the below line if you have a setup that supports HDR10+
           # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
           # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
@@ -70,3 +60,9 @@ radarr:
           # - f700d29429c023a5734505e77daeaea7 # DV (FEL)
         quality_profiles:
           - name: SQP-2
+
+      - trash_ids:
+          - 9c38ebb7384dada637be8899efa68e6f # SDR
+        quality_profiles:
+          - name: SQP-2
+            # score: 0 # Uncomment this line to enable SDR releases

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-2                                                         #
-# Updated: 2023-10-01                                                                             #
+# Updated: 2023-10-03                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-2                                                         #
-# Updated: 2023-09-18                                                                             #
+# Updated: 2023-10-01                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -18,24 +18,47 @@ radarr:
 
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
+      # Movie Versions
       - trash_ids:
-      # HDR Formats
-          # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+        quality_profiles:
+          - name: SQP-2
+            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
 
-      # IMAX-E
-          # Uncomment the next line if you prefer IMAX Enhanced releases
-          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+      # Misc
+      - trash_ids:
+          - 2899d84dc9372de3408e6d8cc18e9666 # x264
+        quality_profiles:
+          - name: SQP-2
+            # score: 0 # Uncomment this line to enable x264 releases
 
-      # x265
-          # Use ONE of the following two options to determine whether all 1080p x265 releases are
-          # blocked, or whether to permit those with DV/HDR
-          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+      # Unwanted
+      - trash_ids:
+          # Uncomment the next six lines to block all x265 HD releases
+          # - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+        # quality_profiles:
+          # - name: SQP-2
+            # score: 0
+      # - trash_ids:
           # - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+        quality_profiles:
+          - name: SQP-2
 
       # Optional
-          # Uncomment any of the following optional custom formats if you want them to be added to
-          # the quality profile
+      - trash_ids:
+          # Comment out the next line if you and all of your users' setups are fully DV compatible
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+        quality_profiles:
+          - name: SQP-2
+
+      - trash_ids:
+          - 9c38ebb7384dada637be8899efa68e6f # SDR
+        quality_profiles:
+          - name: SQP-2
+            # score: 0 # Uncomment this line to enable SDR releases
+
+      - trash_ids:
+          # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # Uncomment the below line if you have a setup that supports HDR10+
           # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
@@ -44,8 +67,6 @@ radarr:
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
           # - f537cf427b64c38c8e36298f657e4828 # Scene
-          # - 0a3f082873eb454bde444150b70253cc # Extras
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
-          - f700d29429c023a5734505e77daeaea7 # DV (FEL)
+          # - f700d29429c023a5734505e77daeaea7 # DV (FEL)
         quality_profiles:
           - name: SQP-2

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-3                                                         #
-# Updated: 2023-10-01                                                                             #
+# Updated: 2023-10-03                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -46,20 +46,10 @@ radarr:
 
       # Optional
       - trash_ids:
-          # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
-        quality_profiles:
-          - name: SQP-3
-
-      - trash_ids:
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
-        quality_profiles:
-          - name: SQP-3
-            # score: 0 # Uncomment this line to enable SDR releases
-
-      - trash_ids:
           # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
+          # Comment out the next line if you and all of your users' setups are fully DV compatible
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
           # Uncomment the below line if you have a setup that supports HDR10+
           # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
           # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
@@ -70,3 +60,9 @@ radarr:
           # - f700d29429c023a5734505e77daeaea7 # DV (FEL)
         quality_profiles:
           - name: SQP-3
+
+      - trash_ids:
+          - 9c38ebb7384dada637be8899efa68e6f # SDR
+        quality_profiles:
+          - name: SQP-3
+            # score: 0 # Uncomment this line to enable SDR releases

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-3                                                         #
-# Updated: 2023-09-18                                                                             #
+# Updated: 2023-10-01                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -18,24 +18,47 @@ radarr:
 
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
+      # Movie Versions
       - trash_ids:
-      # HDR Formats
-          # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+        quality_profiles:
+          - name: SQP-3
+            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
 
-      # IMAX-E
-          # Uncomment the next line if you prefer IMAX Enhanced releases
-          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+      # Misc
+      - trash_ids:
+          - 2899d84dc9372de3408e6d8cc18e9666 # x264
+        quality_profiles:
+          - name: SQP-3
+            # score: 0 # Uncomment this line to enable x264 releases
 
-      # x265
-          # Use ONE of the following two options to determine whether all 1080p x265 releases are
-          # blocked, or whether to permit those with DV/HDR
-          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+      # Unwanted
+      - trash_ids:
+          # Uncomment the next six lines to block all x265 HD releases
+          # - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+        # quality_profiles:
+          # - name: SQP-3
+            # score: 0
+      # - trash_ids:
           # - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+        quality_profiles:
+          - name: SQP-3
 
       # Optional
-          # Uncomment any of the following optional custom formats if you want them to be added to
-          # the quality profile
+      - trash_ids:
+          # Comment out the next line if you and all of your users' setups are fully DV compatible
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+        quality_profiles:
+          - name: SQP-3
+
+      - trash_ids:
+          - 9c38ebb7384dada637be8899efa68e6f # SDR
+        quality_profiles:
+          - name: SQP-3
+            # score: 0 # Uncomment this line to enable SDR releases
+
+      - trash_ids:
+          # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # Uncomment the below line if you have a setup that supports HDR10+
           # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
@@ -44,8 +67,6 @@ radarr:
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
           # - f537cf427b64c38c8e36298f657e4828 # Scene
-          # - 0a3f082873eb454bde444150b70253cc # Extras
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
-          - f700d29429c023a5734505e77daeaea7 # DV (FEL)
+          # - f700d29429c023a5734505e77daeaea7 # DV (FEL)
         quality_profiles:
           - name: SQP-3

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-4                                                         #
-# Updated: 2023-09-18                                                                             #
+# Updated: 2023-10-01                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -18,24 +18,47 @@ radarr:
 
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
+      # Movie Versions
       - trash_ids:
-      # HDR Formats
-          # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+        quality_profiles:
+          - name: SQP-4
+            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
 
-      # IMAX-E
-          # Uncomment the next line if you prefer IMAX Enhanced releases
-          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+      # Misc
+      - trash_ids:
+          - 2899d84dc9372de3408e6d8cc18e9666 # x264
+        quality_profiles:
+          - name: SQP-4
+            # score: 0 # Uncomment this line to enable x264 releases
 
-      # x265
-          # Use ONE of the following two options to determine whether all 1080p x265 releases are
-          # blocked, or whether to permit those with DV/HDR
-          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+      # Unwanted
+      - trash_ids:
+          # Uncomment the next six lines to block all x265 HD releases
+          # - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+        # quality_profiles:
+          # - name: SQP-4
+            # score: 0
+      # - trash_ids:
           # - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+        quality_profiles:
+          - name: SQP-4
 
       # Optional
-          # Uncomment any of the following optional custom formats if you want them to be added to
-          # the quality profile
+      - trash_ids:
+          # Comment out the next line if you and all of your users' setups are fully DV compatible
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+        quality_profiles:
+          - name: SQP-4
+
+      - trash_ids:
+          - 9c38ebb7384dada637be8899efa68e6f # SDR
+        quality_profiles:
+          - name: SQP-4
+            # score: 0 # Uncomment this line to enable SDR releases
+
+      - trash_ids:
+          # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # Uncomment the below line if you have a setup that supports HDR10+
           # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
@@ -44,8 +67,6 @@ radarr:
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
           # - f537cf427b64c38c8e36298f657e4828 # Scene
-          # - 0a3f082873eb454bde444150b70253cc # Extras
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
-          - f700d29429c023a5734505e77daeaea7 # DV (FEL)
+          # - f700d29429c023a5734505e77daeaea7 # DV (FEL)
         quality_profiles:
           - name: SQP-4

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -46,20 +46,10 @@ radarr:
 
       # Optional
       - trash_ids:
-          # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
-        quality_profiles:
-          - name: SQP-4
-
-      - trash_ids:
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
-        quality_profiles:
-          - name: SQP-4
-            # score: 0 # Uncomment this line to enable SDR releases
-
-      - trash_ids:
           # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
+          # Comment out the next line if you and all of your users' setups are fully DV compatible
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
           # Uncomment the below line if you have a setup that supports HDR10+
           # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
           # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
@@ -70,3 +60,9 @@ radarr:
           # - f700d29429c023a5734505e77daeaea7 # DV (FEL)
         quality_profiles:
           - name: SQP-4
+
+      - trash_ids:
+          - 9c38ebb7384dada637be8899efa68e6f # SDR
+        quality_profiles:
+          - name: SQP-4
+            # score: 0 # Uncomment this line to enable SDR releases

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-4                                                         #
-# Updated: 2023-10-01                                                                             #
+# Updated: 2023-10-03                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -46,20 +46,10 @@ radarr:
 
       # Optional
       - trash_ids:
-          # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
-        quality_profiles:
-          - name: SQP-5
-
-      - trash_ids:
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
-        quality_profiles:
-          - name: SQP-5
-            # score: 0 # Uncomment this line to enable SDR releases
-
-      - trash_ids:
           # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
+          # Comment out the next line if you and all of your users' setups are fully DV compatible
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
           # Uncomment the below line if you have a setup that supports HDR10+
           # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
           # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
@@ -70,3 +60,9 @@ radarr:
           # - f700d29429c023a5734505e77daeaea7 # DV (FEL)
         quality_profiles:
           - name: SQP-5
+
+      - trash_ids:
+          - 9c38ebb7384dada637be8899efa68e6f # SDR
+        quality_profiles:
+          - name: SQP-5
+            # score: 0 # Uncomment this line to enable SDR releases

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-5                                                         #
-# Updated: 2023-09-18                                                                             #
+# Updated: 2023-10-01                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -18,24 +18,47 @@ radarr:
 
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
+      # Movie Versions
       - trash_ids:
-      # HDR Formats
-          # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+        quality_profiles:
+          - name: SQP-5
+            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
 
-      # IMAX-E
-          # Uncomment the next line if you prefer IMAX Enhanced releases
-          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+      # Misc
+      - trash_ids:
+          - 2899d84dc9372de3408e6d8cc18e9666 # x264
+        quality_profiles:
+          - name: SQP-5
+            # score: 0 # Uncomment this line to enable x264 releases
 
-      # x265
-          # Use ONE of the following two options to determine whether all 1080p x265 releases are
-          # blocked, or whether to permit those with DV/HDR
-          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+      # Unwanted
+      - trash_ids:
+          # Uncomment the next six lines to block all x265 HD releases
+          # - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+        # quality_profiles:
+          # - name: SQP-5
+            # score: 0
+      # - trash_ids:
           # - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+        quality_profiles:
+          - name: SQP-5
 
       # Optional
-          # Uncomment any of the following optional custom formats if you want them to be added to
-          # the quality profile
+      - trash_ids:
+          # Comment out the next line if you and all of your users' setups are fully DV compatible
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+        quality_profiles:
+          - name: SQP-5
+
+      - trash_ids:
+          - 9c38ebb7384dada637be8899efa68e6f # SDR
+        quality_profiles:
+          - name: SQP-5
+            # score: 0 # Uncomment this line to enable SDR releases
+
+      - trash_ids:
+          # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # Uncomment the below line if you have a setup that supports HDR10+
           # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
@@ -44,8 +67,6 @@ radarr:
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
           # - f537cf427b64c38c8e36298f657e4828 # Scene
-          # - 0a3f082873eb454bde444150b70253cc # Extras
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
-          - f700d29429c023a5734505e77daeaea7 # DV (FEL)
+          # - f700d29429c023a5734505e77daeaea7 # DV (FEL)
         quality_profiles:
           - name: SQP-5

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-5                                                         #
-# Updated: 2023-10-01                                                                             #
+# Updated: 2023-10-03                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB                                              #
-# Updated: 2023-10-01                                                                             #
+# Updated: 2023-10-03                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB                                              #
-# Updated: 2023-09-24                                                                             #
+# Updated: 2023-10-01                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -17,10 +17,10 @@ radarr:
       - template: uhd-bluray-web
 
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
-
     custom_formats:
+      # Audio
       - trash_ids:
-      # Audio - Uncomment the next section if you are using the Advanced Audio Formats
+          # Uncomment the next section to enable Advanced Audio Formats
           # - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
           # - 2f22d89048b01681dde8afe203bf2e95 # DTS X
           # - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
@@ -35,14 +35,27 @@ radarr:
           # - 1c1a4c5e823891c75bc50380a6866f73 # DTS
           # - 240770601cc226190c367ef59aba7463 # AAC
           # - c2998bd0d90ed5621d8df281e839436e # DD
+        quality_profiles:
+          - name: UHD Bluray + WEB
 
-      # HDR Formats
+      # Movie Versions
+      - trash_ids:
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+        quality_profiles:
+          - name: UHD Bluray + WEB
+            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
+
+      # Optional
+      - trash_ids:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
           # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
           # - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
+        quality_profiles:
+          - name: UHD Bluray + WEB
 
-      # Optional
+      - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
         quality_profiles:
           - name: UHD Bluray + WEB
+            # score: 0 # Uncomment this line to allow SDR releases

--- a/sonarr/includes/web-2160p-v4.yml
+++ b/sonarr/includes/web-2160p-v4.yml
@@ -31,11 +31,14 @@ custom_formats:
       - 17e889ce13117940092308f48b48b45b # HLG
       - 2a7e3be05d3861d6df7171ec74cad727 # PQ
 
-      # Unwanted UHD
+      # Unwanted
       - 85c61753df5da1fb2aab6f2a47426b09 # BR-DISK
       - 9c11cd3f07101cdba90a2d81cf0e56b4 # LQ
       - 47435ece6b99a0b477caf360e79ba0bb # x265 (HD)
       - fbcb31d8dabd2a319072b84fc0b7249c # Extras
+
+      # Optional UHD
+      - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
 
       # Misc
       - ec8fa7296b64e8cd390a1600981f3923 # Repack/Proper

--- a/sonarr/templates/web-2160p-v4.yml
+++ b/sonarr/templates/web-2160p-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: WEB-2160p (V4)                                                #
-# Updated: 2023-10-01                                                                             #
+# Updated: 2023-10-03                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/sonarr/templates/web-2160p-v4.yml
+++ b/sonarr/templates/web-2160p-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: WEB-2160p (V4)                                                #
-# Updated: 2023-09-24                                                                             #
+# Updated: 2023-10-01                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -19,14 +19,18 @@ sonarr:
 
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
-      - trash_ids:
       # HDR Formats
+      - trash_ids:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
           # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
           # - 0dad0a507451acddd754fe6dc3a7f5e7 # HDR10Plus Boost
+        quality_profiles:
+          - name: WEB-2160p
 
       # Optional
+      - trash_ids:
           - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
         quality_profiles:
           - name: WEB-2160p
+            # score: 0 # Uncomment this line to enable SDR releases


### PR DESCRIPTION
- Re-added all recommended optional custom formats to main guide and SQP includes
- Revised 'Golden Rule' defaults for all profiles so they match the guide recommendations
- Added revised sections to main guide and SQP templates to allow users to override recommended optional custom format scores
- Recategorised custom format groupings to use the same header names as the guides
- Updated file modification dates

Users will need to update their templates