### PR TITLE
Fix: Add Bluray-576p Quality to Radarr Anime Quality Profile Include

### DIFF
--- a/radarr/includes/quality-profiles/radarr-quality-profile-anime.yml
+++ b/radarr/includes/quality-profiles/radarr-quality-profile-anime.yml
@@ -25,6 +25,7 @@ quality_profiles:
           - WEBDL-720p
           - WEBRip-720p
           - HDTV-720p
+      - name: Bluray-576p
       - name: Bluray-480p
       - name: WEB 480p
         qualities:


### PR DESCRIPTION
- Add Bluray-576p quality to Radarr Anime quality profile include