### PR TITLE
fix: Revert Repack/Proper Custom Format Changes

### DIFF
--- a/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web.yml
@@ -19,9 +19,8 @@ custom_formats:
       - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
 
       # Misc
-      - a06f27e686bda44e19515ccf51af279f # Repack
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
       - ae43b294509409a6a13919dedd4764c4 # Repack2
-      - 482da74d7594524acd1cd9de5d5fb0dc # Proper
 
       # Unwanted
       - ed38b889b31be83fda192888e2286d83 # BR-DISK

--- a/radarr/includes/custom-formats/radarr-custom-formats-remux-web-1080p.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-remux-web-1080p.yml
@@ -20,9 +20,8 @@ custom_formats:
       - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
 
       # Misc
-      - a06f27e686bda44e19515ccf51af279f # Repack
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
       - ae43b294509409a6a13919dedd4764c4 # Repack2
-      - 482da74d7594524acd1cd9de5d5fb0dc # Proper
 
       # Unwanted
       - ed38b889b31be83fda192888e2286d83 # BR-DISK

--- a/radarr/includes/custom-formats/radarr-custom-formats-remux-web-2160p.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-remux-web-2160p.yml
@@ -33,9 +33,8 @@ custom_formats:
       - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
 
       # Misc
-      - a06f27e686bda44e19515ccf51af279f # Repack
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
       - ae43b294509409a6a13919dedd4764c4 # Repack2
-      - 482da74d7594524acd1cd9de5d5fb0dc # Proper
 
       # Unwanted
       - ed38b889b31be83fda192888e2286d83 # BR-DISK

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web.yml
@@ -32,9 +32,8 @@ custom_formats:
       - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
 
       # Misc
-      - a06f27e686bda44e19515ccf51af279f # Repack
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
       - ae43b294509409a6a13919dedd4764c4 # Repack2
-      - 482da74d7594524acd1cd9de5d5fb0dc # Proper
 
       # Unwanted
       - ed38b889b31be83fda192888e2286d83 # BR-DISK

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-1080p.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-1080p.yml
@@ -34,9 +34,8 @@ custom_formats:
       - 5608c71bcebba0a5e666223bae8c9227 # HD Bluray Tier 03
 
       # Misc
-      - a06f27e686bda44e19515ccf51af279f # Repack
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
       - ae43b294509409a6a13919dedd4764c4 # Repack2
-      - 482da74d7594524acd1cd9de5d5fb0dc # Proper
 
       # Unwanted
       - ed38b889b31be83fda192888e2286d83 # BR-DISK

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
@@ -51,9 +51,8 @@ custom_formats:
       - e71939fae578037e7aed3ee219bbe7c1 # UHD Bluray Tier 03
 
       # Misc
-      - a06f27e686bda44e19515ccf51af279f # Repack
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
       - ae43b294509409a6a13919dedd4764c4 # Repack2
-      - 482da74d7594524acd1cd9de5d5fb0dc # Proper
 
       # Unwanted
       - ed38b889b31be83fda192888e2286d83 # BR-DISK

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-2.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-2.yml
@@ -52,9 +52,8 @@ custom_formats:
       - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
 
       # Misc
-      - a06f27e686bda44e19515ccf51af279f # Repack
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
       - ae43b294509409a6a13919dedd4764c4 # Repack2
-      - 482da74d7594524acd1cd9de5d5fb0dc # Proper
       - 2899d84dc9372de3408e6d8cc18e9666 # x264
 
       # Unwanted

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-3.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-3.yml
@@ -49,9 +49,8 @@ custom_formats:
       - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
 
       # Misc
-      - a06f27e686bda44e19515ccf51af279f # Repack
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
       - ae43b294509409a6a13919dedd4764c4 # Repack2
-      - 482da74d7594524acd1cd9de5d5fb0dc # Proper
       - 2899d84dc9372de3408e6d8cc18e9666 # x264
 
       # Unwanted

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-4.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-4.yml
@@ -49,9 +49,8 @@ custom_formats:
       - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
 
       # Misc
-      - a06f27e686bda44e19515ccf51af279f # Repack
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
       - ae43b294509409a6a13919dedd4764c4 # Repack2
-      - 482da74d7594524acd1cd9de5d5fb0dc # Proper
       - 2899d84dc9372de3408e6d8cc18e9666 # x264
 
       # Unwanted

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-5.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-5.yml
@@ -52,9 +52,8 @@ custom_formats:
       - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
 
       # Misc
-      - a06f27e686bda44e19515ccf51af279f # Repack
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
       - ae43b294509409a6a13919dedd4764c4 # Repack2
-      - 482da74d7594524acd1cd9de5d5fb0dc # Proper
       - 2899d84dc9372de3408e6d8cc18e9666 # x264
 
       # Unwanted

--- a/radarr/templates/french-hd-bluray-web-multi.yml
+++ b/radarr/templates/french-hd-bluray-web-multi.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: French HD Bluray + WEB (MULTi)                                #
-# Updated: 2024-01-08                                                                             #
+# Updated: 2024-01-10                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -12,7 +12,7 @@
 
 ###################################################################################################
 # Modèle de configuration Recyclarr : French HD Bluray + WEB (MULTi)                              #
-# Mis à jour : 2024-01-08                                                                         #
+# Mis à jour : 2024-01-10                                                                         #
 # Documentation (en anglais) : https://recyclarr.dev                                              #
 # Note: Si vous utilisez plusieurs profils dans une seule instance, veuillez lire                 #
 # documentation suivante sur la mise en commun des instances (en anglais) :                       #
@@ -98,9 +98,8 @@ radarr:
           # - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
 
           # ===== Misc =====
-          - a06f27e686bda44e19515ccf51af279f  # Repack
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
-          - 482da74d7594524acd1cd9de5d5fb0dc  # Proper
 
           # ===== Indésirables =====
           - ed38b889b31be83fda192888e2286d83  # BR-DISK

--- a/radarr/templates/french-hd-bluray-web-vostfr.yml
+++ b/radarr/templates/french-hd-bluray-web-vostfr.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: French HD Bluray + WEB (VOSTFR)                               #
-# Updated: 2024-01-08                                                                             #
+# Updated: 2024-01-10                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -12,7 +12,7 @@
 
 ###################################################################################################
 # Modèle de configuration Recyclarr : French HD Bluray + WEB (VOSTFR)                             #
-# Mis à jour : 2024-01-08                                                                         #
+# Mis à jour : 2024-01-10                                                                         #
 # Documentation (en anglais) : https://recyclarr.dev                                              #
 # Note: Si vous utilisez plusieurs profils dans une seule instance, veuillez lire                 #
 # documentation suivante sur la mise en commun des instances (en anglais) :                       #
@@ -94,9 +94,8 @@ radarr:
           - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
 
           # ===== Misc =====
-          - a06f27e686bda44e19515ccf51af279f  # Repack
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
-          - 482da74d7594524acd1cd9de5d5fb0dc  # Proper
 
           # ===== Indésirables =====
           - ed38b889b31be83fda192888e2286d83  # BR-DISK

--- a/radarr/templates/french-remux-web-1080p-multi.yml
+++ b/radarr/templates/french-remux-web-1080p-multi.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: French HD Remux + WEB (MULTi)                                 #
-# Updated: 2024-01-08                                                                             #
+# Updated: 2024-01-10                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -12,7 +12,7 @@
 
 ###################################################################################################
 # Modèle de configuration Recyclarr : French HD Remux + WEB (MULTi)                               #
-# Mis à jour : 2024-01-08                                                                         #
+# Mis à jour : 2024-01-10                                                                         #
 # Documentation (en anglais) : https://recyclarr.dev                                              #
 # Note: Si vous utilisez plusieurs profils dans une seule instance, veuillez lire                 #
 # documentation suivante sur la mise en commun des instances (en anglais) :                       #
@@ -119,9 +119,8 @@ radarr:
           # - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
 
           # ===== Misc =====
-          - a06f27e686bda44e19515ccf51af279f  # Repack
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
-          - 482da74d7594524acd1cd9de5d5fb0dc  # Proper
 
           # ===== Indésirables =====
           - ed38b889b31be83fda192888e2286d83  # BR-DISK

--- a/radarr/templates/french-remux-web-1080p-vostfr.yml
+++ b/radarr/templates/french-remux-web-1080p-vostfr.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: French HD Remux + WEB (VOSTFR)                                #
-# Updated: 2024-01-08                                                                             #
+# Updated: 2024-01-10                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -12,7 +12,7 @@
 
 ###################################################################################################
 # Modèle de configuration Recyclarr : French HD Remux + WEB (VOSTFR)                              #
-# Mis à jour : 2024-01-08                                                                         #
+# Mis à jour : 2024-01-10                                                                         #
 # Documentation (en anglais) : https://recyclarr.dev                                              #
 # Note: Si vous utilisez plusieurs profils dans une seule instance, veuillez lire                 #
 # documentation suivante sur la mise en commun des instances (en anglais) :                       #
@@ -111,9 +111,8 @@ radarr:
           - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
 
           # ===== Misc =====
-          - a06f27e686bda44e19515ccf51af279f  # Repack
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
-          - 482da74d7594524acd1cd9de5d5fb0dc  # Proper
 
           # ===== Indésirables =====
           - ed38b889b31be83fda192888e2286d83  # BR-DISK

--- a/radarr/templates/french-remux-web-2160p-multi.yml
+++ b/radarr/templates/french-remux-web-2160p-multi.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: French Remux + WEB 2160p (MULTi)                              #
-# Updated: 2024-01-08                                                                             #
+# Updated: 2024-01-10                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -12,7 +12,7 @@
 
 ###################################################################################################
 # Modèle de configuration Recyclarr : French Remux + WEB 2160p (MULTi)                            #
-# Mis à jour : 2024-01-08                                                                         #
+# Mis à jour : 2024-01-10                                                                         #
 # Documentation (en anglais) : https://recyclarr.dev                                              #
 # Note: Si vous utilisez plusieurs profils dans une seule instance, veuillez lire                 #
 # documentation suivante sur la mise en commun des instances (en anglais) :                       #
@@ -140,9 +140,8 @@ radarr:
           # - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
 
           # ===== Misc =====
-          - a06f27e686bda44e19515ccf51af279f  # Repack
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
-          - 482da74d7594524acd1cd9de5d5fb0dc  # Proper
 
           # ===== Indésirables =====
           - ed38b889b31be83fda192888e2286d83  # BR-DISK

--- a/radarr/templates/french-remux-web-2160p-vostfr.yml
+++ b/radarr/templates/french-remux-web-2160p-vostfr.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: French Remux + WEB 2160p (VOSTFR)                             #
-# Updated: 2024-01-08                                                                             #
+# Updated: 2024-01-10                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -12,7 +12,7 @@
 
 ###################################################################################################
 # Modèle de configuration Recyclarr : French Remux + WEB 2160p (VOSTFR)                           #
-# Mis à jour : 2024-01-08                                                                         #
+# Mis à jour : 2024-01-10                                                                         #
 # Documentation (en anglais) : https://recyclarr.dev                                              #
 # Note: Si vous utilisez plusieurs profils dans une seule instance, veuillez lire                 #
 # documentation suivante sur la mise en commun des instances (en anglais) :                       #
@@ -132,9 +132,8 @@ radarr:
           - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
 
           # ===== Misc =====
-          - a06f27e686bda44e19515ccf51af279f  # Repack
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
-          - 482da74d7594524acd1cd9de5d5fb0dc  # Proper
 
           # ===== Indésirables =====
           - ed38b889b31be83fda192888e2286d83  # BR-DISK

--- a/radarr/templates/french-uhd-bluray-web-multi.yml
+++ b/radarr/templates/french-uhd-bluray-web-multi.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: French UHD Bluray + WEB (MULTi)                               #
-# Updated: 2024-01-08                                                                             #
+# Updated: 2024-01-10                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -12,7 +12,7 @@
 
 ###################################################################################################
 # Modèle de configuration Recyclarr : French UHD Bluray + WEB (MULTi)                             #
-# Mis à jour : 2024-01-08                                                                         #
+# Mis à jour : 2024-01-10                                                                         #
 # Documentation (en anglais) : https://recyclarr.dev                                              #
 # Note: Si vous utilisez plusieurs profils dans une seule instance, veuillez lire                 #
 # documentation suivante sur la mise en commun des instances (en anglais) :                       #
@@ -139,9 +139,8 @@ radarr:
           # - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
 
           # ===== Misc =====
-          - a06f27e686bda44e19515ccf51af279f  # Repack
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
-          - 482da74d7594524acd1cd9de5d5fb0dc  # Proper
 
           # ===== Indésirables =====
           - ed38b889b31be83fda192888e2286d83  # BR-DISK

--- a/radarr/templates/french-uhd-bluray-web-vostfr.yml
+++ b/radarr/templates/french-uhd-bluray-web-vostfr.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: French UHD Bluray + WEB (VOSTFR)                              #
-# Updated: 2024-01-08                                                                             #
+# Updated: 2024-01-10                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -12,7 +12,7 @@
 
 ###################################################################################################
 # Modèle de configuration Recyclarr : French UHD Bluray + WEB (VOSTFR)                            #
-# Mis à jour : 2024-01-08                                                                         #
+# Mis à jour : 2024-01-10                                                                         #
 # Documentation (en anglais) : https://recyclarr.dev                                              #
 # Note: Si vous utilisez plusieurs profils dans une seule instance, veuillez lire                 #
 # documentation suivante sur la mise en commun des instances (en anglais) :                       #
@@ -131,9 +131,8 @@ radarr:
           - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
 
           # ===== Misc =====
-          - a06f27e686bda44e19515ccf51af279f  # Repack
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
           - ae43b294509409a6a13919dedd4764c4  # Repack2
-          - 482da74d7594524acd1cd9de5d5fb0dc  # Proper
 
           # ===== Indésirables =====
           - ed38b889b31be83fda192888e2286d83  # BR-DISK

--- a/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-1080p.yml
+++ b/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-1080p.yml
@@ -8,10 +8,9 @@ custom_formats:
       - fbcb31d8dabd2a319072b84fc0b7249c # Extras
 
       # Misc
-      - f11b533d6db941b84f36cab756b29ea5 # Repack
+      - ec8fa7296b64e8cd390a1600981f3923 # Repack/Proper
       - eb3d5cc0a2be0db205fb823640db6a3c # Repack v2
       - 44e7c4de10ae50265753082e5dc76047 # Repack v3
-      - 003262633471ef9477b1d685a73b5e93 # Proper
 
       # Streaming Services
       - bbcaf03147de0f73be2be4a9078dfa03 # 4OD

--- a/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-2160p.yml
+++ b/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-2160p.yml
@@ -24,10 +24,9 @@ custom_formats:
       - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
 
       # Misc
-      - f11b533d6db941b84f36cab756b29ea5 # Repack
+      - ec8fa7296b64e8cd390a1600981f3923 # Repack/Proper
       - eb3d5cc0a2be0db205fb823640db6a3c # Repack v2
       - 44e7c4de10ae50265753082e5dc76047 # Repack v3
-      - 003262633471ef9477b1d685a73b5e93 # Proper
 
       # Streaming Services
       - bbcaf03147de0f73be2be4a9078dfa03 # 4OD

--- a/sonarr/templates/french-web-1080p-multi-v4.yml
+++ b/sonarr/templates/french-web-1080p-multi-v4.yml
@@ -35,10 +35,9 @@ sonarr:
           - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
 
           # ===== Misc =====
-          - f11b533d6db941b84f36cab756b29ea5  # Repack
+          - ec8fa7296b64e8cd390a1600981f3923  # Repack/Proper
           - eb3d5cc0a2be0db205fb823640db6a3c  # Repack v2
           - 44e7c4de10ae50265753082e5dc76047  # Repack v3
-          - 003262633471ef9477b1d685a73b5e93  # Proper
 
           # ===== Services de Streaming =====
           - d660701077794679fd59e8bdf4ce3a29  # AMZN

--- a/sonarr/templates/french-web-1080p-vostfr-v4.yml
+++ b/sonarr/templates/french-web-1080p-vostfr-v4.yml
@@ -29,10 +29,9 @@ sonarr:
           - ea0bb4b6ba388992fad1092703b5ff7b  # FastSUB
 
           # ===== Misc =====
-          - f11b533d6db941b84f36cab756b29ea5  # Repack
+          - ec8fa7296b64e8cd390a1600981f3923  # Repack/Proper
           - eb3d5cc0a2be0db205fb823640db6a3c  # Repack v2
           - 44e7c4de10ae50265753082e5dc76047  # Repack v3
-          - 003262633471ef9477b1d685a73b5e93  # Proper
 
           # ===== Services de Streaming =====
           - d660701077794679fd59e8bdf4ce3a29  # AMZN

--- a/sonarr/templates/french-web-2160p-multi-v4.yml
+++ b/sonarr/templates/french-web-2160p-multi-v4.yml
@@ -53,10 +53,9 @@ sonarr:
           - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
 
           # ===== Misc =====
-          - f11b533d6db941b84f36cab756b29ea5  # Repack
+          - ec8fa7296b64e8cd390a1600981f3923  # Repack/Proper
           - eb3d5cc0a2be0db205fb823640db6a3c  # Repack v2
           - 44e7c4de10ae50265753082e5dc76047  # Repack v3
-          - 003262633471ef9477b1d685a73b5e93  # Proper
 
           # ===== Services de Streaming =====
           - d660701077794679fd59e8bdf4ce3a29  # AMZN

--- a/sonarr/templates/french-web-2160p-vostfr-v4.yml
+++ b/sonarr/templates/french-web-2160p-vostfr-v4.yml
@@ -47,10 +47,9 @@ sonarr:
           - ea0bb4b6ba388992fad1092703b5ff7b  # FastSUB
 
           # ===== Misc =====
-          - f11b533d6db941b84f36cab756b29ea5  # Repack
+          - ec8fa7296b64e8cd390a1600981f3923  # Repack/Proper
           - eb3d5cc0a2be0db205fb823640db6a3c  # Repack v2
           - 44e7c4de10ae50265753082e5dc76047  # Repack v3
-          - 003262633471ef9477b1d685a73b5e93  # Proper
 
           # ===== Services de Streaming =====
           - d660701077794679fd59e8bdf4ce3a29  # AMZN


### PR DESCRIPTION
- Revert all includes and French templates to use previous combined `Repack/Proper` custom format