### PR TITLE
feat: Add Streaming Services and DV HDR10+ Boost Option

### DIFF
--- a/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web.yml
@@ -47,8 +47,9 @@ custom_formats:
       - 917d1f2c845b2b466036b0cc2d7c72a3 # FOD
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-      - 6185878161f1e2eef9cd0641a0d09eae # iP
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
+      - 6185878161f1e2eef9cd0641a0d09eae # iP
+      - c3492a26af412e385404eade438ec51c # ITVX
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
       - fbca986396c5e695ef7b2def3c755d01 # OViD
@@ -58,6 +59,7 @@ custom_formats:
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
       - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
       - 279bda7434fd9075786de274e6c3c202 # U-NEXT
+      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: HD Bluray + WEB
         score: 0

--- a/radarr/includes/custom-formats/radarr-custom-formats-remux-web-1080p.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-remux-web-1080p.yml
@@ -50,6 +50,7 @@ custom_formats:
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
       - 6185878161f1e2eef9cd0641a0d09eae # iP
+      - c3492a26af412e385404eade438ec51c # ITVX
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
       - fbca986396c5e695ef7b2def3c755d01 # OViD
@@ -59,5 +60,6 @@ custom_formats:
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
       - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
       - 279bda7434fd9075786de274e6c3c202 # U-NEXT
+      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: Remux + WEB 1080p

--- a/radarr/includes/custom-formats/radarr-custom-formats-remux-web-2160p.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-remux-web-2160p.yml
@@ -66,6 +66,7 @@ custom_formats:
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
       - 6185878161f1e2eef9cd0641a0d09eae # iP
+      - c3492a26af412e385404eade438ec51c # ITVX
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
       - fbca986396c5e695ef7b2def3c755d01 # OViD
@@ -75,5 +76,6 @@ custom_formats:
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
       - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
       - 279bda7434fd9075786de274e6c3c202 # U-NEXT
+      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: Remux + WEB 2160p

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web.yml
@@ -65,6 +65,7 @@ custom_formats:
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
       - 6185878161f1e2eef9cd0641a0d09eae # iP
+      - c3492a26af412e385404eade438ec51c # ITVX
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
       - fbca986396c5e695ef7b2def3c755d01 # OViD
@@ -74,5 +75,6 @@ custom_formats:
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
       - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
       - 279bda7434fd9075786de274e6c3c202 # U-NEXT
+      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: UHD Bluray + WEB

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-1080p.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-1080p.yml
@@ -45,6 +45,7 @@ custom_formats:
       - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
       - 0a3f082873eb454bde444150b70253cc # Extras
+      - a5d148168c4506b55cf53984107c396e # Hi10P
 
       # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
@@ -68,6 +69,7 @@ custom_formats:
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
       - 6185878161f1e2eef9cd0641a0d09eae # iP
+      - c3492a26af412e385404eade438ec51c # ITVX
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
       - fbca986396c5e695ef7b2def3c755d01 # OViD
@@ -77,6 +79,7 @@ custom_formats:
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
       - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
       - 279bda7434fd9075786de274e6c3c202 # U-NEXT
+      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: SQP-1 (1080p)
         score: 0

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
@@ -61,6 +61,7 @@ custom_formats:
       - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
       - 0a3f082873eb454bde444150b70253cc # Extras
+      - a5d148168c4506b55cf53984107c396e # Hi10P
 
       # Optional
       - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
@@ -89,6 +90,7 @@ custom_formats:
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
       - 6185878161f1e2eef9cd0641a0d09eae # iP
+      - c3492a26af412e385404eade438ec51c # ITVX
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
       - fbca986396c5e695ef7b2def3c755d01 # OViD
@@ -98,6 +100,7 @@ custom_formats:
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
       - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
       - 279bda7434fd9075786de274e6c3c202 # U-NEXT
+      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: SQP-1 (2160p)
         score: 0

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-2.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-2.yml
@@ -90,6 +90,7 @@ custom_formats:
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
       - 6185878161f1e2eef9cd0641a0d09eae # iP
+      - c3492a26af412e385404eade438ec51c # ITVX
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
       - fbca986396c5e695ef7b2def3c755d01 # OViD
@@ -99,6 +100,7 @@ custom_formats:
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
       - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
       - 279bda7434fd9075786de274e6c3c202 # U-NEXT
+      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: SQP-2
         score: 0

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-3.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-3.yml
@@ -87,6 +87,7 @@ custom_formats:
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
       - 6185878161f1e2eef9cd0641a0d09eae # iP
+      - c3492a26af412e385404eade438ec51c # ITVX
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
       - fbca986396c5e695ef7b2def3c755d01 # OViD
@@ -96,6 +97,7 @@ custom_formats:
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
       - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
       - 279bda7434fd9075786de274e6c3c202 # U-NEXT
+      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: SQP-3
         score: 0

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-4.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-4.yml
@@ -87,6 +87,7 @@ custom_formats:
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
       - 6185878161f1e2eef9cd0641a0d09eae # iP
+      - c3492a26af412e385404eade438ec51c # ITVX
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
       - fbca986396c5e695ef7b2def3c755d01 # OViD
@@ -96,6 +97,7 @@ custom_formats:
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
       - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
       - 279bda7434fd9075786de274e6c3c202 # U-NEXT
+      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: SQP-4
         score: 0

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-5.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-5.yml
@@ -90,6 +90,7 @@ custom_formats:
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
       - 6185878161f1e2eef9cd0641a0d09eae # iP
+      - c3492a26af412e385404eade438ec51c # ITVX
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
       - fbca986396c5e695ef7b2def3c755d01 # OViD
@@ -99,6 +100,7 @@ custom_formats:
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
       - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
       - 279bda7434fd9075786de274e6c3c202 # U-NEXT
+      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: SQP-5
         score: 0

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -73,8 +73,10 @@ radarr:
       - trash_ids:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
-          # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
+
+          # HDR10+ Boost - Uncomment the next two lines if any of your devices DO support HDR10+
           # - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
+          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
         quality_profiles:
           - name: Remux + WEB 2160p
 

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Remux + WEB 2160p                                             #
-# Updated: 2023-12-30                                                                             #
+# Updated: 2024-02-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (2160p)                                                 #
-# Updated: 2023-10-07                                                                             #
+# Updated: 2024-02-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -55,11 +55,13 @@ radarr:
 
       # Optional
       - trash_ids:
+          # Uncomment the next two lines if you have a setup that supports HDR10+
+          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
+          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+
           # Uncomment any of the following optional custom formats if you want them to be added to
           # the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          # Uncomment the next line if you have a setup that supports HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
           # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-2                                                         #
-# Updated: 2023-12-30                                                                             #
+# Updated: 2024-02-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -49,12 +49,15 @@ radarr:
 
       # Optional
       - trash_ids:
-          # Uncomment any of the following if you want them to be added to the quality profile
-          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
+          # Uncomment the next two lines if you have a setup that supports HDR10+
+          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
+          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
-          # Uncomment the below line if you have a setup that supports HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
+
+          # Uncomment any of the following if you want them to be added to the quality profile
+          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-3                                                         #
-# Updated: 2023-12-30                                                                             #
+# Updated: 2024-02-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -49,12 +49,15 @@ radarr:
 
       # Optional
       - trash_ids:
-          # Uncomment any of the following if you want them to be added to the quality profile
-          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
+          # Uncomment the next two lines if you have a setup that supports HDR10+
+          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
+          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
-          # Uncomment the below line if you have a setup that supports HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
+
+          # Uncomment any of the following if you want them to be added to the quality profile
+          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-4                                                         #
-# Updated: 2023-12-30                                                                             #
+# Updated: 2024-02-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -49,12 +49,15 @@ radarr:
 
       # Optional
       - trash_ids:
-          # Uncomment any of the following if you want them to be added to the quality profile
-          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
+          # Uncomment the next two lines if you have a setup that supports HDR10+
+          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
+          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
-          # Uncomment the below line if you have a setup that supports HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
+
+          # Uncomment any of the following if you want them to be added to the quality profile
+          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-5                                                         #
-# Updated: 2023-12-30                                                                             #
+# Updated: 2024-02-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -49,12 +49,15 @@ radarr:
 
       # Optional
       - trash_ids:
-          # Uncomment any of the following if you want them to be added to the quality profile
-          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
+          # Uncomment the next two lines if you have a setup that supports HDR10+
+          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
+          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
-          # Uncomment the below line if you have a setup that supports HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
+
+          # Uncomment any of the following if you want them to be added to the quality profile
+          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -73,8 +73,10 @@ radarr:
       - trash_ids:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
-          # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
+
+          # HDR10+ Boost - Uncomment the next line if any of your devices DO support HDR10+
           # - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
+          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
         quality_profiles:
           - name: UHD Bluray + WEB
 

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB                                              #
-# Updated: 2023-12-30                                                                             #
+# Updated: 2024-02-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-1080p.yml
+++ b/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-1080p.yml
@@ -27,6 +27,7 @@ custom_formats:
       - f6cce30f1733d5c8194222a7507909bb # HULU
       - dc503e2425126fa1d0a9ad6168c83b3f # iP
       - 0ac24a2a68a9700bcb7eeca8e5cd644c # iT
+      - fa5a16b951004c23e980d2913694a137 # ITVX
       - 81d1fbf600e2540cee87f3a23f9d3c1c # MAX
       - d34870697c9db575f17700212167be23 # NF
       - b2b980877494b560443631eb1f473867 # NLZ
@@ -40,6 +41,7 @@ custom_formats:
       - d100ea972d1af2150b65b1cffb80f6b5 # TVer
       - 0e99e7cc719a8a73b2668c3a0c3fe10c # U-NEXT
       - 5d2317d99af813b6529c7ebf01c83533 # VDL
+      - 93c9d1e566dca8b34d57f5efbbf85f28 # VIU
 
       # HQ Source Groups
       - e6258996055b9fbab7e9cb2f75819294 # WEB Tier 01

--- a/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-2160p.yml
+++ b/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-2160p.yml
@@ -43,6 +43,7 @@ custom_formats:
       - f6cce30f1733d5c8194222a7507909bb # HULU
       - dc503e2425126fa1d0a9ad6168c83b3f # iP
       - 0ac24a2a68a9700bcb7eeca8e5cd644c # iT
+      - fa5a16b951004c23e980d2913694a137 # ITVX
       - 81d1fbf600e2540cee87f3a23f9d3c1c # MAX
       - d34870697c9db575f17700212167be23 # NF
       - b2b980877494b560443631eb1f473867 # NLZ
@@ -56,6 +57,7 @@ custom_formats:
       - d100ea972d1af2150b65b1cffb80f6b5 # TVer
       - 0e99e7cc719a8a73b2668c3a0c3fe10c # U-NEXT
       - 5d2317d99af813b6529c7ebf01c83533 # VDL
+      - 93c9d1e566dca8b34d57f5efbbf85f28 # VIU
       - 43b3cf48cb385cd3eac608ee6bca7f09 # UHD Streaming Boost
       - d2d299244a92b8a52d4921ce3897a256 # UHD Streaming Cut
 

--- a/sonarr/templates/web-2160p-v4.yml
+++ b/sonarr/templates/web-2160p-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: WEB-2160p (V4)                                                #
-# Updated: 2023-12-30                                                                             #
+# Updated: 2024-02-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/sonarr/templates/web-2160p-v4.yml
+++ b/sonarr/templates/web-2160p-v4.yml
@@ -26,8 +26,10 @@ sonarr:
       - trash_ids:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
-          # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
-          # - 0dad0a507451acddd754fe6dc3a7f5e7 # HDR10Plus Boost
+
+          # HDR10+ Boost - Uncomment the next two lines if any of your devices DO support HDR10+
+          # - 0dad0a507451acddd754fe6dc3a7f5e7 # HDR10+ Boost
+          # - 385e9e8581d33133c3961bdcdeffb7b4 # DV HDR10+ Boost
         quality_profiles:
           - name: WEB-2160p
 


### PR DESCRIPTION
- Added ITVX and VIU streaming services to Sonarr and Radarr custom format includes
- Added Hi10P to SQP-1 custom format includes as unwanted
- Added DV HDR10+ Boost to 4K optional section in all templates
- Reformatted HDR10+ section in all templates for consistency