### PR TITLE
feat: Template Updates 2024-05-21

### DIFF
--- a/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web.yml
@@ -42,25 +42,16 @@ custom_formats:
       # Streaming Services
       - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
       - 40e9380490e748672c2522eaaeb692f7 # ATVP
-      - f6ff65b3f4b464a79dcc75950fe20382 # CRAV
       - 84272245b2988854bfb76a16e60baea5 # DSNP
-      - 917d1f2c845b2b466036b0cc2d7c72a3 # FOD
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-      - 834b2c0ba0a8596029b4479a29e1a032 # HTSR
-      - 6185878161f1e2eef9cd0641a0d09eae # iP
-      - c3492a26af412e385404eade438ec51c # ITVX
+      - e0ec9672be6cac914ffad34a6b077209 # iT
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-      - fbca986396c5e695ef7b2def3c755d01 # OViD
-      - bf7e73dd1d85b12cc527dc619761c840 # Pathe
       - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
-      - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
-      - 279bda7434fd9075786de274e6c3c202 # U-NEXT
-      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: HD Bluray + WEB
         score: 0

--- a/radarr/includes/custom-formats/radarr-custom-formats-remux-web-1080p.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-remux-web-1080p.yml
@@ -43,24 +43,15 @@ custom_formats:
       # Streaming Services
       - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
       - 40e9380490e748672c2522eaaeb692f7 # ATVP
-      - f6ff65b3f4b464a79dcc75950fe20382 # CRAV
       - 84272245b2988854bfb76a16e60baea5 # DSNP
-      - 917d1f2c845b2b466036b0cc2d7c72a3 # FOD
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-      - 834b2c0ba0a8596029b4479a29e1a032 # HTSR
-      - 6185878161f1e2eef9cd0641a0d09eae # iP
-      - c3492a26af412e385404eade438ec51c # ITVX
+      - e0ec9672be6cac914ffad34a6b077209 # iT
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-      - fbca986396c5e695ef7b2def3c755d01 # OViD
-      - bf7e73dd1d85b12cc527dc619761c840 # Pathe
       - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
-      - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
-      - 279bda7434fd9075786de274e6c3c202 # U-NEXT
-      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: Remux + WEB 1080p

--- a/radarr/includes/custom-formats/radarr-custom-formats-remux-web-2160p.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-remux-web-2160p.yml
@@ -45,9 +45,6 @@ custom_formats:
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
       - 0a3f082873eb454bde444150b70253cc # Extras
 
-      # Optional UHD
-      - 9c38ebb7384dada637be8899efa68e6f # SDR
-
       # Streaming Services
       - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
       - 16622a6911d1ab5d5b8b713d5b0036d4 # CRiT
@@ -59,24 +56,15 @@ custom_formats:
       # Streaming Services
       - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
       - 40e9380490e748672c2522eaaeb692f7 # ATVP
-      - f6ff65b3f4b464a79dcc75950fe20382 # CRAV
       - 84272245b2988854bfb76a16e60baea5 # DSNP
-      - 917d1f2c845b2b466036b0cc2d7c72a3 # FOD
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-      - 834b2c0ba0a8596029b4479a29e1a032 # HTSR
-      - 6185878161f1e2eef9cd0641a0d09eae # iP
-      - c3492a26af412e385404eade438ec51c # ITVX
+      - e0ec9672be6cac914ffad34a6b077209 # iT
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-      - fbca986396c5e695ef7b2def3c755d01 # OViD
-      - bf7e73dd1d85b12cc527dc619761c840 # Pathe
       - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
-      - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
-      - 279bda7434fd9075786de274e6c3c202 # U-NEXT
-      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: Remux + WEB 2160p

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web.yml
@@ -44,9 +44,6 @@ custom_formats:
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
       - 0a3f082873eb454bde444150b70253cc # Extras
 
-      # Optional UHD
-      - 9c38ebb7384dada637be8899efa68e6f # SDR
-
       # Streaming Services
       - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
       - 16622a6911d1ab5d5b8b713d5b0036d4 # CRiT
@@ -58,24 +55,15 @@ custom_formats:
       # Streaming Services
       - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
       - 40e9380490e748672c2522eaaeb692f7 # ATVP
-      - f6ff65b3f4b464a79dcc75950fe20382 # CRAV
       - 84272245b2988854bfb76a16e60baea5 # DSNP
-      - 917d1f2c845b2b466036b0cc2d7c72a3 # FOD
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-      - 834b2c0ba0a8596029b4479a29e1a032 # HTSR
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-      - 6185878161f1e2eef9cd0641a0d09eae # iP
-      - c3492a26af412e385404eade438ec51c # ITVX
+      - e0ec9672be6cac914ffad34a6b077209 # iT
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-      - fbca986396c5e695ef7b2def3c755d01 # OViD
-      - bf7e73dd1d85b12cc527dc619761c840 # Pathe
       - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
-      - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
-      - 279bda7434fd9075786de274e6c3c202 # U-NEXT
-      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: UHD Bluray + WEB

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-1080p.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-1080p.yml
@@ -45,7 +45,7 @@ custom_formats:
       - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
       - 0a3f082873eb454bde444150b70253cc # Extras
-      - a5d148168c4506b55cf53984107c396e # Hi10P
+      - a5d148168c4506b55cf53984107c396e # 10bit
 
       # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
@@ -62,25 +62,16 @@ custom_formats:
       # Streaming Services
       - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
       - 40e9380490e748672c2522eaaeb692f7 # ATVP
-      - f6ff65b3f4b464a79dcc75950fe20382 # CRAV
       - 84272245b2988854bfb76a16e60baea5 # DSNP
-      - 917d1f2c845b2b466036b0cc2d7c72a3 # FOD
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-      - 834b2c0ba0a8596029b4479a29e1a032 # HTSR
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-      - 6185878161f1e2eef9cd0641a0d09eae # iP
-      - c3492a26af412e385404eade438ec51c # ITVX
+      - e0ec9672be6cac914ffad34a6b077209 # iT
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-      - fbca986396c5e695ef7b2def3c755d01 # OViD
-      - bf7e73dd1d85b12cc527dc619761c840 # Pathe
       - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
-      - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
-      - 279bda7434fd9075786de274e6c3c202 # U-NEXT
-      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: SQP-1 (1080p)
         score: 0

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
@@ -66,7 +66,6 @@ custom_formats:
       # Optional
       - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
       - cae4ca30163749b891686f95532519bd # AV1
-      - 9c38ebb7384dada637be8899efa68e6f # SDR
 
       # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
@@ -83,25 +82,16 @@ custom_formats:
       # Streaming Services
       - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
       - 40e9380490e748672c2522eaaeb692f7 # ATVP
-      - f6ff65b3f4b464a79dcc75950fe20382 # CRAV
       - 84272245b2988854bfb76a16e60baea5 # DSNP
-      - 917d1f2c845b2b466036b0cc2d7c72a3 # FOD
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-      - 834b2c0ba0a8596029b4479a29e1a032 # HTSR
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-      - 6185878161f1e2eef9cd0641a0d09eae # iP
-      - c3492a26af412e385404eade438ec51c # ITVX
+      - e0ec9672be6cac914ffad34a6b077209 # iT
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-      - fbca986396c5e695ef7b2def3c755d01 # OViD
-      - bf7e73dd1d85b12cc527dc619761c840 # Pathe
       - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
-      - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
-      - 279bda7434fd9075786de274e6c3c202 # U-NEXT
-      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: SQP-1 (2160p)
         score: 0

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-2.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-2.yml
@@ -66,7 +66,6 @@ custom_formats:
 
       # Optional
       - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
-      - 9c38ebb7384dada637be8899efa68e6f # SDR
 
       # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
@@ -83,25 +82,16 @@ custom_formats:
       # Streaming Services
       - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
       - 40e9380490e748672c2522eaaeb692f7 # ATVP
-      - f6ff65b3f4b464a79dcc75950fe20382 # CRAV
       - 84272245b2988854bfb76a16e60baea5 # DSNP
-      - 917d1f2c845b2b466036b0cc2d7c72a3 # FOD
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-      - 834b2c0ba0a8596029b4479a29e1a032 # HTSR
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-      - 6185878161f1e2eef9cd0641a0d09eae # iP
-      - c3492a26af412e385404eade438ec51c # ITVX
+      - e0ec9672be6cac914ffad34a6b077209 # iT
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-      - fbca986396c5e695ef7b2def3c755d01 # OViD
-      - bf7e73dd1d85b12cc527dc619761c840 # Pathe
       - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
-      - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
-      - 279bda7434fd9075786de274e6c3c202 # U-NEXT
-      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: SQP-2
         score: 0

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-3.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-3.yml
@@ -63,7 +63,6 @@ custom_formats:
 
       # Optional
       - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
-      - 9c38ebb7384dada637be8899efa68e6f # SDR
 
       # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
@@ -80,25 +79,16 @@ custom_formats:
       # Streaming Services
       - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
       - 40e9380490e748672c2522eaaeb692f7 # ATVP
-      - f6ff65b3f4b464a79dcc75950fe20382 # CRAV
       - 84272245b2988854bfb76a16e60baea5 # DSNP
-      - 917d1f2c845b2b466036b0cc2d7c72a3 # FOD
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-      - 834b2c0ba0a8596029b4479a29e1a032 # HTSR
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-      - 6185878161f1e2eef9cd0641a0d09eae # iP
-      - c3492a26af412e385404eade438ec51c # ITVX
+      - e0ec9672be6cac914ffad34a6b077209 # iT
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-      - fbca986396c5e695ef7b2def3c755d01 # OViD
-      - bf7e73dd1d85b12cc527dc619761c840 # Pathe
       - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
-      - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
-      - 279bda7434fd9075786de274e6c3c202 # U-NEXT
-      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: SQP-3
         score: 0

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-4.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-4.yml
@@ -63,7 +63,6 @@ custom_formats:
 
       # Optional
       - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
-      - 9c38ebb7384dada637be8899efa68e6f # SDR
 
       # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
@@ -80,25 +79,16 @@ custom_formats:
       # Streaming Services
       - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
       - 40e9380490e748672c2522eaaeb692f7 # ATVP
-      - f6ff65b3f4b464a79dcc75950fe20382 # CRAV
       - 84272245b2988854bfb76a16e60baea5 # DSNP
-      - 917d1f2c845b2b466036b0cc2d7c72a3 # FOD
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-      - 834b2c0ba0a8596029b4479a29e1a032 # HTSR
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-      - 6185878161f1e2eef9cd0641a0d09eae # iP
-      - c3492a26af412e385404eade438ec51c # ITVX
+      - e0ec9672be6cac914ffad34a6b077209 # iT
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-      - fbca986396c5e695ef7b2def3c755d01 # OViD
-      - bf7e73dd1d85b12cc527dc619761c840 # Pathe
       - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
-      - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
-      - 279bda7434fd9075786de274e6c3c202 # U-NEXT
-      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: SQP-4
         score: 0

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-5.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-5.yml
@@ -66,7 +66,6 @@ custom_formats:
 
       # Optional
       - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
-      - 9c38ebb7384dada637be8899efa68e6f # SDR
 
       # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
@@ -83,25 +82,16 @@ custom_formats:
       # Streaming Services
       - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
       - 40e9380490e748672c2522eaaeb692f7 # ATVP
-      - f6ff65b3f4b464a79dcc75950fe20382 # CRAV
       - 84272245b2988854bfb76a16e60baea5 # DSNP
-      - 917d1f2c845b2b466036b0cc2d7c72a3 # FOD
       - 509e5f41146e278f9eab1ddaceb34515 # HBO
       - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-      - 834b2c0ba0a8596029b4479a29e1a032 # HTSR
       - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-      - 6185878161f1e2eef9cd0641a0d09eae # iP
-      - c3492a26af412e385404eade438ec51c # ITVX
+      - e0ec9672be6cac914ffad34a6b077209 # iT
       - 6a061313d22e51e0f25b7cd4dc065233 # MAX
       - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-      - fbca986396c5e695ef7b2def3c755d01 # OViD
-      - bf7e73dd1d85b12cc527dc619761c840 # Pathe
       - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
-      - f1b0bae9bc222dab32c1b38b5a7a1088 # TVer
-      - 279bda7434fd9075786de274e6c3c202 # U-NEXT
-      - 1b355ff093fd1064b75ea98c616881b1 # VIU
     quality_profiles:
       - name: SQP-5
         score: 0

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -83,7 +83,7 @@ radarr:
       # Optional SDR
       # Only ever use ONE of the following custom formats:
       # SDR - block ALL SDR releases
-      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
+      # SDR (no WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
           # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Remux + WEB 2160p                                             #
-# Updated: 2024-02-18                                                                             #
+# Updated: 2024-05-21                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -80,8 +80,12 @@ radarr:
         quality_profiles:
           - name: Remux + WEB 2160p
 
+      # Optional SDR
+      # Only ever use ONE of the following custom formats:
+      # SDR - block ALL SDR releases
+      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
+          # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)
         quality_profiles:
           - name: Remux + WEB 2160p
-            # score: 0 # Uncomment this line to allow SDR releases

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (2160p)                                                 #
-# Updated: 2024-02-18                                                                             #
+# Updated: 2024-05-21                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -70,11 +70,15 @@ radarr:
         quality_profiles:
           - name: SQP-1 (2160p)
 
+      # Optional SDR
+      # Only ever use ONE of the following custom formats:
+      # SDR - block ALL SDR releases
+      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
+          # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)
         quality_profiles:
           - name: SQP-1 (2160p)
-            # score: 0 # Uncomment this line to allow SDR releases
 
       - trash_ids:
           - cae4ca30163749b891686f95532519bd # AV1

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -73,7 +73,7 @@ radarr:
       # Optional SDR
       # Only ever use ONE of the following custom formats:
       # SDR - block ALL SDR releases
-      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
+      # SDR (no WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
           # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-2                                                         #
-# Updated: 2024-02-18                                                                             #
+# Updated: 2024-05-21                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -67,8 +67,12 @@ radarr:
         quality_profiles:
           - name: SQP-2
 
+      # Optional SDR
+      # Only ever use ONE of the following custom formats:
+      # SDR - block ALL SDR releases
+      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
+          # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)
         quality_profiles:
           - name: SQP-2
-            # score: 0 # Uncomment this line to enable SDR releases

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -70,7 +70,7 @@ radarr:
       # Optional SDR
       # Only ever use ONE of the following custom formats:
       # SDR - block ALL SDR releases
-      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
+      # SDR (no WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
           # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-3                                                         #
-# Updated: 2024-02-18                                                                             #
+# Updated: 2024-05-21                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -67,8 +67,12 @@ radarr:
         quality_profiles:
           - name: SQP-3
 
+      # Optional SDR
+      # Only ever use ONE of the following custom formats:
+      # SDR - block ALL SDR releases
+      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
+          # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)
         quality_profiles:
           - name: SQP-3
-            # score: 0 # Uncomment this line to enable SDR releases

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -70,7 +70,7 @@ radarr:
       # Optional SDR
       # Only ever use ONE of the following custom formats:
       # SDR - block ALL SDR releases
-      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
+      # SDR (no WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
           # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-4                                                         #
-# Updated: 2024-02-18                                                                             #
+# Updated: 2024-05-21                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -67,8 +67,12 @@ radarr:
         quality_profiles:
           - name: SQP-4
 
+      # Optional SDR
+      # Only ever use ONE of the following custom formats:
+      # SDR - block ALL SDR releases
+      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
+          # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)
         quality_profiles:
           - name: SQP-4
-            # score: 0 # Uncomment this line to enable SDR releases

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -70,7 +70,7 @@ radarr:
       # Optional SDR
       # Only ever use ONE of the following custom formats:
       # SDR - block ALL SDR releases
-      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
+      # SDR (no WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
           # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-5                                                         #
-# Updated: 2024-02-18                                                                             #
+# Updated: 2024-05-21                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -67,8 +67,12 @@ radarr:
         quality_profiles:
           - name: SQP-5
 
+      # Optional SDR
+      # Only ever use ONE of the following custom formats:
+      # SDR - block ALL SDR releases
+      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
+          # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)
         quality_profiles:
           - name: SQP-5
-            # score: 0 # Uncomment this line to enable SDR releases

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -70,7 +70,7 @@ radarr:
       # Optional SDR
       # Only ever use ONE of the following custom formats:
       # SDR - block ALL SDR releases
-      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
+      # SDR (no WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
           # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -83,7 +83,7 @@ radarr:
       # Optional SDR
       # Only ever use ONE of the following custom formats:
       # SDR - block ALL SDR releases
-      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
+      # SDR (no WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
           # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB                                              #
-# Updated: 2024-02-18                                                                             #
+# Updated: 2024-05-21                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -80,8 +80,12 @@ radarr:
         quality_profiles:
           - name: UHD Bluray + WEB
 
+      # Optional SDR
+      # Only ever use ONE of the following custom formats:
+      # SDR - block ALL SDR releases
+      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 9c38ebb7384dada637be8899efa68e6f # SDR
+          # - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)
         quality_profiles:
           - name: UHD Bluray + WEB
-            # score: 0 # Uncomment this line to allow SDR releases

--- a/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-1080p.yml
+++ b/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-1080p.yml
@@ -13,36 +13,22 @@ custom_formats:
       - 44e7c4de10ae50265753082e5dc76047 # Repack v3
 
       # Streaming Services
-      - bbcaf03147de0f73be2be4a9078dfa03 # 4OD
-      - fcc09418f67ccaddcf3b641a22c5cfd7 # ALL4
       - d660701077794679fd59e8bdf4ce3a29 # AMZN
       - f67c9ca88f463a48346062e8ad07713f # ATVP
       - 77a7b25585c18af08f60b1547bb9b4fb # CC
-      - 4e9a630db98d5391aec1368a0256e2fe # CRAV
       - 36b72f59f4ea20aad9316f475f2d9fbb # DCU
       - 89358767a60cc28783cdc3d0be9388a4 # DSNP
-      - 7be9c0572d8cd4f81785dacf7e85985e # FOD
       - 7a235133c87f7da4c8cccceca7e3c7a6 # HBO
       - a880d6abc21e7c16884f3ae393f84179 # HMAX
-      - 4404ad44d87ccbb82746e180713112fb # HTSR
       - f6cce30f1733d5c8194222a7507909bb # Hulu
-      - dc503e2425126fa1d0a9ad6168c83b3f # iP
       - 0ac24a2a68a9700bcb7eeca8e5cd644c # iT
       - fa5a16b951004c23e980d2913694a137 # ITVX
       - 81d1fbf600e2540cee87f3a23f9d3c1c # MAX
       - d34870697c9db575f17700212167be23 # NF
-      - b2b980877494b560443631eb1f473867 # NLZ
-      - fb1a91cdc0f26f7ca0696e0e95274645 # OViD
       - 1656adc6d7bb2c8cca6acfb6592db421 # PCOK
       - c67a75ae4a1715f2bb4d492755ba4195 # PMTP
-      - 3ac5d84fce98bab1b531393e9c82f467 # QIBI
-      - c30d2958827d1867c73318a5a2957eb1 # RED
       - ae58039e1319178e6be73caab5c42166 # SHO
       - 1efe8da11bfd74fbbcd4d8117ddb9213 # STAN
-      - d100ea972d1af2150b65b1cffb80f6b5 # TVer
-      - 0e99e7cc719a8a73b2668c3a0c3fe10c # U-NEXT
-      - 5d2317d99af813b6529c7ebf01c83533 # VDL
-      - 93c9d1e566dca8b34d57f5efbbf85f28 # VIU
 
       # HQ Source Groups
       - e6258996055b9fbab7e9cb2f75819294 # WEB Tier 01

--- a/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-2160p.yml
+++ b/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-2160p.yml
@@ -20,45 +20,28 @@ custom_formats:
       - 47435ece6b99a0b477caf360e79ba0bb # x265 (HD)
       - fbcb31d8dabd2a319072b84fc0b7249c # Extras
 
-      # Optional UHD
-      - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
-
       # Misc
       - ec8fa7296b64e8cd390a1600981f3923 # Repack/Proper
       - eb3d5cc0a2be0db205fb823640db6a3c # Repack v2
       - 44e7c4de10ae50265753082e5dc76047 # Repack v3
 
       # Streaming Services
-      - bbcaf03147de0f73be2be4a9078dfa03 # 4OD
-      - fcc09418f67ccaddcf3b641a22c5cfd7 # ALL4
       - d660701077794679fd59e8bdf4ce3a29 # AMZN
       - f67c9ca88f463a48346062e8ad07713f # ATVP
       - 77a7b25585c18af08f60b1547bb9b4fb # CC
-      - 4e9a630db98d5391aec1368a0256e2fe # CRAV
       - 36b72f59f4ea20aad9316f475f2d9fbb # DCU
       - 89358767a60cc28783cdc3d0be9388a4 # DSNP
-      - 7be9c0572d8cd4f81785dacf7e85985e # FOD
       - 7a235133c87f7da4c8cccceca7e3c7a6 # HBO
       - a880d6abc21e7c16884f3ae393f84179 # HMAX
-      - 4404ad44d87ccbb82746e180713112fb # HTSR
       - f6cce30f1733d5c8194222a7507909bb # Hulu
-      - dc503e2425126fa1d0a9ad6168c83b3f # iP
       - 0ac24a2a68a9700bcb7eeca8e5cd644c # iT
       - fa5a16b951004c23e980d2913694a137 # ITVX
       - 81d1fbf600e2540cee87f3a23f9d3c1c # MAX
       - d34870697c9db575f17700212167be23 # NF
-      - b2b980877494b560443631eb1f473867 # NLZ
-      - fb1a91cdc0f26f7ca0696e0e95274645 # OViD
       - 1656adc6d7bb2c8cca6acfb6592db421 # PCOK
       - c67a75ae4a1715f2bb4d492755ba4195 # PMTP
-      - 3ac5d84fce98bab1b531393e9c82f467 # QIBI
-      - c30d2958827d1867c73318a5a2957eb1 # RED
       - ae58039e1319178e6be73caab5c42166 # SHO
       - 1efe8da11bfd74fbbcd4d8117ddb9213 # STAN
-      - d100ea972d1af2150b65b1cffb80f6b5 # TVer
-      - 0e99e7cc719a8a73b2668c3a0c3fe10c # U-NEXT
-      - 5d2317d99af813b6529c7ebf01c83533 # VDL
-      - 93c9d1e566dca8b34d57f5efbbf85f28 # VIU
       - 43b3cf48cb385cd3eac608ee6bca7f09 # UHD Streaming Boost
       - d2d299244a92b8a52d4921ce3897a256 # UHD Streaming Cut
 

--- a/sonarr/templates/web-2160p-v4.yml
+++ b/sonarr/templates/web-2160p-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: WEB-2160p (V4)                                                #
-# Updated: 2024-02-18                                                                             #
+# Updated: 2024-05-21                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -54,8 +54,12 @@ sonarr:
         quality_profiles:
           - name: WEB-2160p
 
+      # Optional SDR
+      # Only ever use ONE of the following custom formats:
+      # SDR - block ALL SDR releases
+      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
+          # - 83304f261cf516bb208c18c54c0adf97 # SDR (no WEBDL)
         quality_profiles:
           - name: WEB-2160p
-            # score: 0 # Uncomment this line to enable SDR releases

--- a/sonarr/templates/web-2160p-v4.yml
+++ b/sonarr/templates/web-2160p-v4.yml
@@ -57,7 +57,7 @@ sonarr:
       # Optional SDR
       # Only ever use ONE of the following custom formats:
       # SDR - block ALL SDR releases
-      # SDR (WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
+      # SDR (no WEBDL) - block UHD/4k Remux and Bluray encode SDR releases, but allow SDR WEB
       - trash_ids:
           - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
           # - 83304f261cf516bb208c18c54c0adf97 # SDR (no WEBDL)


### PR DESCRIPTION
- Brought the templates and includes up to date with the guides as of 2024-05-21
- Moved SDR custom formats out of includes and into templates
- Removed non-general streaming services

Notes for users:
- Non-general streaming services will now need to be manually added to your templates
- All users will need to update their templates to the latest version(s)