### PR TITLE
feat: Update 2024-10-02

### DIFF
--- a/includes.json
+++ b/includes.json
@@ -175,8 +175,16 @@
       "id": "sonarr-v4-quality-profile-web-1080p"
     },
     {
+      "template": "sonarr/includes/quality-profiles/sonarr-v4-quality-profile-web-1080p-alternative.yml",
+      "id": "sonarr-v4-quality-profile-web-1080p-alternative"
+    },
+    {
       "template": "sonarr/includes/quality-profiles/sonarr-v4-quality-profile-web-2160p.yml",
       "id": "sonarr-v4-quality-profile-web-2160p"
+    },
+    {
+      "template": "sonarr/includes/quality-profiles/sonarr-v4-quality-profile-web-2160p-alternative.yml",
+      "id": "sonarr-v4-quality-profile-web-2160p-alternative"
     },
     {
       "template": "sonarr/includes/quality-profiles/sonarr-v4-quality-profile-anime-fr.yml",

--- a/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web.yml
@@ -1,15 +1,5 @@
 custom_formats:
   - trash_ids:
-      # Movie Versions
-      - 570bc9ebecd92723d2d21500f4be314c # Remaster
-      - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-      - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-      - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-      - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
-      - 957d0f44b592285f26449575e8b1167e # Special Edition
-      - eecf3a857724171f968a66cb5719e152 # IMAX
-      - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
-
       # HQ Release Groups
       - ed27ebfef2f323e964fb1f61391bcb35 # HD Bluray Tier 01
       - c20c8647f2746a1f4c4262b0fbbeeeae # HD Bluray Tier 02

--- a/radarr/includes/custom-formats/radarr-custom-formats-remux-web-1080p.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-remux-web-1080p.yml
@@ -1,16 +1,5 @@
 custom_formats:
   - trash_ids:
-      # Movie Versions
-      - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-      - 570bc9ebecd92723d2d21500f4be314c # Remaster
-      - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-      - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-      - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-      - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
-      - 957d0f44b592285f26449575e8b1167e # Special Edition
-      - eecf3a857724171f968a66cb5719e152 # IMAX
-      - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
-
       # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
       - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02

--- a/radarr/includes/custom-formats/radarr-custom-formats-remux-web-2160p.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-remux-web-2160p.yml
@@ -13,17 +13,6 @@ custom_formats:
       - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
       - 9364dd386c9b4a1100dde8264690add7 # HLG
 
-      # Movie Versions
-      - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-      - 570bc9ebecd92723d2d21500f4be314c # Remaster
-      - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-      - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-      - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-      - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
-      - 957d0f44b592285f26449575e8b1167e # Special Edition
-      - eecf3a857724171f968a66cb5719e152 # IMAX
-      - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
-
       # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
       - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web.yml
@@ -13,16 +13,6 @@ custom_formats:
       - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
       - 9364dd386c9b4a1100dde8264690add7 # HLG
 
-      # Movie Versions
-      - 570bc9ebecd92723d2d21500f4be314c # Remaster
-      - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-      - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-      - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-      - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
-      - 957d0f44b592285f26449575e8b1167e # Special Edition
-      - eecf3a857724171f968a66cb5719e152 # IMAX
-      - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
-
       # HQ Release Groups
       - 4d74ac4c4db0b64bff6ce0cffef99bf0 # UHD Bluray Tier 01
       - a58f517a70193f8e578056642178419d # UHD Bluray Tier 02

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-1080p.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-1080p.yml
@@ -16,14 +16,6 @@ custom_formats:
       - 240770601cc226190c367ef59aba7463 # AAC
       - c2998bd0d90ed5621d8df281e839436e # DD
 
-      # Movie Versions
-      - 570bc9ebecd92723d2d21500f4be314c # Remaster
-      - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-      - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-      - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-      - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
-      - 957d0f44b592285f26449575e8b1167e # Special Edition
-
       # HQ Release Groups
       - 5153ec7413d9dae44e24275589b5e944 # BHDStudio
       - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
@@ -30,14 +30,6 @@ custom_formats:
       - 9364dd386c9b4a1100dde8264690add7 # HLG
       - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
 
-      # Movie Versions
-      - 570bc9ebecd92723d2d21500f4be314c # Remaster
-      - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-      - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-      - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-      - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
-      - 957d0f44b592285f26449575e8b1167e # Special Edition
-
       # HQ Release Groups
       - 5153ec7413d9dae44e24275589b5e944 # BHDStudio
       - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-2.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-2.yml
@@ -29,17 +29,6 @@ custom_formats:
       - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
       - 9364dd386c9b4a1100dde8264690add7 # HLG
 
-      # Movie Versions
-      - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-      - 570bc9ebecd92723d2d21500f4be314c # Remaster
-      - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-      - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-      - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-      - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
-      - 957d0f44b592285f26449575e8b1167e # Special Edition
-      - eecf3a857724171f968a66cb5719e152 # IMAX
-      - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
-
       # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
       - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-3.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-3.yml
@@ -29,17 +29,6 @@ custom_formats:
       - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
       - 9364dd386c9b4a1100dde8264690add7 # HLG
 
-      # Movie Versions
-      - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-      - 570bc9ebecd92723d2d21500f4be314c # Remaster
-      - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-      - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-      - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-      - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
-      - 957d0f44b592285f26449575e8b1167e # Special Edition
-      - eecf3a857724171f968a66cb5719e152 # IMAX
-      - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
-
       # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
       - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-4.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-4.yml
@@ -29,17 +29,6 @@ custom_formats:
       - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
       - 9364dd386c9b4a1100dde8264690add7 # HLG
 
-      # Movie Versions
-      - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-      - 570bc9ebecd92723d2d21500f4be314c # Remaster
-      - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-      - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-      - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-      - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
-      - 957d0f44b592285f26449575e8b1167e # Special Edition
-      - eecf3a857724171f968a66cb5719e152 # IMAX
-      - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
-
       # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
       - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-5.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-5.yml
@@ -29,17 +29,6 @@ custom_formats:
       - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
       - 9364dd386c9b4a1100dde8264690add7 # HLG
 
-      # Movie Versions
-      - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-      - 570bc9ebecd92723d2d21500f4be314c # Remaster
-      - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-      - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-      - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-      - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
-      - 957d0f44b592285f26449575e8b1167e # Special Edition
-      - eecf3a857724171f968a66cb5719e152 # IMAX
-      - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
-
       # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
       - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -22,10 +22,17 @@ radarr:
     custom_formats:
       # Movie Versions
       - trash_ids:
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+      # Uncomment any of the following lines to prefer these movie versions
+          # - 570bc9ebecd92723d2d21500f4be314c # Remaster
+          # - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
+          # - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
+          # - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
+          # - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
+          # - 957d0f44b592285f26449575e8b1167e # Special Edition
+          # - eecf3a857724171f968a66cb5719e152 # IMAX
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
         assign_scores_to:
           - name: HD Bluray + WEB
-            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
 
       # Optional
       - trash_ids:

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB                                               #
-# Updated: 2024-08-08                                                                             #
+# Updated: 2024-10-02                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -41,7 +41,7 @@ radarr:
       - trash_ids:
           # Uncomment the next six lines to allow x265 HD releases with HDR/DV
           # - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
-        # quality_profiles:
+        # assign_scores_to:
           # - name: HD Bluray + WEB
             # score: 0
       # - trash_ids:

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -43,10 +43,18 @@ radarr:
 
       # Movie Versions
       - trash_ids:
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+      # Uncomment any of the following lines to prefer these movie versions
+          # - 0f12c086e289cf966fa5948eac571f44 # Hybrid
+          # - 570bc9ebecd92723d2d21500f4be314c # Remaster
+          # - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
+          # - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
+          # - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
+          # - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
+          # - 957d0f44b592285f26449575e8b1167e # Special Edition
+          # - eecf3a857724171f968a66cb5719e152 # IMAX
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
         assign_scores_to:
           - name: Remux + WEB 1080p
-            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
 
       # Optional
       - trash_ids:

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Remux + WEB 1080p                                             #
-# Updated: 2024-08-08                                                                             #
+# Updated: 2024-10-02                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -43,10 +43,18 @@ radarr:
 
       # Movie Versions
       - trash_ids:
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+      # Uncomment any of the following lines to prefer these movie versions
+          # - 0f12c086e289cf966fa5948eac571f44 # Hybrid
+          # - 570bc9ebecd92723d2d21500f4be314c # Remaster
+          # - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
+          # - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
+          # - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
+          # - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
+          # - 957d0f44b592285f26449575e8b1167e # Special Edition
+          # - eecf3a857724171f968a66cb5719e152 # IMAX
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
         assign_scores_to:
           - name: Remux + WEB 2160p
-            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
 
       # Optional
       - trash_ids:

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Remux + WEB 2160p                                             #
-# Updated: 2024-08-08                                                                             #
+# Updated: 2024-10-02                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-1-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-1080p.yml
@@ -28,6 +28,13 @@ radarr:
     custom_formats:
       # Movie Versions
       - trash_ids:
+      # Uncomment any of the next six lines to prefer these movie versions
+          # - 570bc9ebecd92723d2d21500f4be314c # Remaster
+          # - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
+          # - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
+          # - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
+          # - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
+          # - 957d0f44b592285f26449575e8b1167e # Special Edition
       # Uncomment the next line if you prefer WEBDL with IMAX Enhanced to BHDStudio
           # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
 

--- a/radarr/templates/sqp/sqp-1-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-1080p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (1080p)                                                 #
-# Updated: 2024-09-17                                                                             #
+# Updated: 2024-10-02                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (2160p)                                                 #
-# Updated: 2024-08-08                                                                             #
+# Updated: 2024-10-02                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -36,14 +36,21 @@ radarr:
     custom_formats:
       # Movie Versions
       - trash_ids:
-          # Uncomment the next line if you prefer 1080p/2160p WEBDL with IMAX Enhanced
+      # Uncomment any of the next six lines to prefer these movie versions
+          # - 570bc9ebecd92723d2d21500f4be314c # Remaster
+          # - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
+          # - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
+          # - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
+          # - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
+          # - 957d0f44b592285f26449575e8b1167e # Special Edition
+      # Uncomment the next line if you prefer 1080p/2160p WEBDL with IMAX Enhanced
           # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
         assign_scores_to:
           - name: SQP-1 (2160p)
 
       # Unwanted
       - trash_ids:
-          # Uncomment the next six lines to block all x265 HD releases
+      # Uncomment the next six lines to block all x265 HD releases
           # - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
         # assign_scores_to:
           # - name: SQP-1 (2160p)

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-2                                                         #
-# Updated: 2024-08-08                                                                             #
+# Updated: 2024-10-02                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -22,11 +22,19 @@ radarr:
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
       # Movie Versions
+      # Uncomment any of the following lines to prefer these movie versions
       - trash_ids:
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          # - 0f12c086e289cf966fa5948eac571f44 # Hybrid
+          # - 570bc9ebecd92723d2d21500f4be314c # Remaster
+          # - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
+          # - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
+          # - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
+          # - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
+          # - 957d0f44b592285f26449575e8b1167e # Special Edition
+          # - eecf3a857724171f968a66cb5719e152 # IMAX
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
         assign_scores_to:
           - name: SQP-2
-            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
 
       # Misc
       - trash_ids:

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -22,11 +22,19 @@ radarr:
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
       # Movie Versions
+      # Uncomment any of the following lines to prefer these movie versions
       - trash_ids:
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          # - 0f12c086e289cf966fa5948eac571f44 # Hybrid
+          # - 570bc9ebecd92723d2d21500f4be314c # Remaster
+          # - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
+          # - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
+          # - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
+          # - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
+          # - 957d0f44b592285f26449575e8b1167e # Special Edition
+          # - eecf3a857724171f968a66cb5719e152 # IMAX
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
         assign_scores_to:
           - name: SQP-3
-            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
 
       # Misc
       - trash_ids:

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-3                                                         #
-# Updated: 2024-08-08                                                                             #
+# Updated: 2024-10-02                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -22,11 +22,19 @@ radarr:
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
       # Movie Versions
+      # Uncomment any of the following lines to prefer these movie versions
       - trash_ids:
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          # - 0f12c086e289cf966fa5948eac571f44 # Hybrid
+          # - 570bc9ebecd92723d2d21500f4be314c # Remaster
+          # - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
+          # - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
+          # - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
+          # - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
+          # - 957d0f44b592285f26449575e8b1167e # Special Edition
+          # - eecf3a857724171f968a66cb5719e152 # IMAX
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
         assign_scores_to:
           - name: SQP-4
-            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
 
       # Misc
       - trash_ids:

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-4                                                         #
-# Updated: 2024-08-08                                                                             #
+# Updated: 2024-10-02                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -22,11 +22,19 @@ radarr:
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
     custom_formats:
       # Movie Versions
+      # Uncomment any of the following lines to prefer these movie versions
       - trash_ids:
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          # - 0f12c086e289cf966fa5948eac571f44 # Hybrid
+          # - 570bc9ebecd92723d2d21500f4be314c # Remaster
+          # - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
+          # - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
+          # - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
+          # - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
+          # - 957d0f44b592285f26449575e8b1167e # Special Edition
+          # - eecf3a857724171f968a66cb5719e152 # IMAX
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
         assign_scores_to:
           - name: SQP-5
-            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
 
       # Misc
       - trash_ids:

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-5                                                         #
-# Updated: 2024-08-08                                                                             #
+# Updated: 2024-10-02                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB                                              #
-# Updated: 2024-08-08                                                                             #
+# Updated: 2024-10-02                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -43,10 +43,17 @@ radarr:
 
       # Movie Versions
       - trash_ids:
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+      # Uncomment any of the following lines to prefer these movie versions
+          # - 570bc9ebecd92723d2d21500f4be314c # Remaster
+          # - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
+          # - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
+          # - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
+          # - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
+          # - 957d0f44b592285f26449575e8b1167e # Special Edition
+          # - eecf3a857724171f968a66cb5719e152 # IMAX
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
         assign_scores_to:
           - name: UHD Bluray + WEB
-            # score: 0 # Uncomment this line to disable prioritised IMAX Enhanced releases
 
       # Optional
       - trash_ids:

--- a/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-web-1080p-alternative.yml
+++ b/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-web-1080p-alternative.yml
@@ -1,0 +1,23 @@
+quality_profiles:
+  - name: WEB-1080p
+    reset_unmatched_scores:
+      enabled: true
+    upgrade:
+      allowed: true
+      until_quality: WEB 1080p
+      until_score: 10000
+    min_format_score: 0
+    quality_sort: top
+    qualities:
+      - name: WEB 1080p
+        qualities:
+          - WEBDL-1080p
+          - WEBRip-1080p
+      - name: Bluray-1080p
+      - name: HDTV-1080p
+      - name: WEB 720p
+        qualities:
+          - WEBDL-720p
+          - WEBRip-720p
+      - name: Bluray-720p
+      - name: HDTV-720p

--- a/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-web-2160p-alternative.yml
+++ b/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-web-2160p-alternative.yml
@@ -1,0 +1,29 @@
+quality_profiles:
+  - name: WEB-2160p
+    reset_unmatched_scores:
+      enabled: true
+    upgrade:
+      allowed: true
+      until_quality: WEB 2160p
+      until_score: 10000
+    min_format_score: 0
+    quality_sort: top
+    qualities:
+      - name: WEB 2160p
+        qualities:
+          - WEBDL-2160p
+          - WEBRip-2160p
+      - name: WEB 1080p
+        qualities:
+          - WEBDL-1080p
+          - WEBRip-1080p
+      - name: Bluray-2160p Remux
+      - name: Bluray-2160p
+      - name: Bluray-1080p
+      - name: HDTV-1080p
+      - name: WEB 720p
+        qualities:
+          - WEBDL-720p
+          - WEBRip-720p
+      - name: Bluray-720p
+      - name: HDTV-720p

--- a/sonarr/templates/web-1080p-v4.yml
+++ b/sonarr/templates/web-1080p-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: WEB-1080p (V4)                                                #
-# Updated: 2024-08-08                                                                             #
+# Updated: 2024-10-02                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -17,7 +17,9 @@ sonarr:
     include:
       # Comment out any of the following includes to disable them
       - template: sonarr-quality-definition-series
+      # Choose between the standard or alternative quality profile setup (choose one only)
       - template: sonarr-v4-quality-profile-web-1080p
+      # - template: sonarr-v4-quality-profile-web-1080p-alternative
       - template: sonarr-v4-custom-formats-web-1080p
 
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/

--- a/sonarr/templates/web-2160p-v4.yml
+++ b/sonarr/templates/web-2160p-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: WEB-2160p (V4)                                                #
-# Updated: 2024-08-08                                                                             #
+# Updated: 2024-10-02                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -17,7 +17,9 @@ sonarr:
     include:
       # Comment out any of the following includes to disable them
       - template: sonarr-quality-definition-series
+      # Choose between the standard or alternative quality profile setup (choose one only)
       - template: sonarr-v4-quality-profile-web-2160p
+      # - template: sonarr-v4-quality-profile-web-2160p-alternative
       - template: sonarr-v4-custom-formats-web-2160p
 
 # Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/


### PR DESCRIPTION
- Replace straggling incidence of `quality_profiles` (deprecated, replaced by `assign_scores_to`)
- Make movie versions optional for all Radarr templates
- Add option for alternative Sonarr quality profile definition/includes