### PR TITLE
fix: Correct Guidance Typo in UHD Bluray + WEB Template

### DIFF
--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -81,7 +81,7 @@ radarr:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
 
-          # HDR10+ Boost - Uncomment the next line if any of your devices DO support HDR10+
+          # HDR10+ Boost - Uncomment the next two lines if any of your devices DO support HDR10+
           # - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
           # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
         assign_scores_to:

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB                                              #
-# Updated: 2024-10-02                                                                             #
+# Updated: 2024-11-25                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #


### PR DESCRIPTION
- Correct a typo in the HDR10+ Boost guidance on the UHD Bluray + WEB template.