### PR TITLE
feat: Add custom format includes for the German Guide

### DIFF
--- a/includes.json
+++ b/includes.json
@@ -97,6 +97,18 @@
       "id": "radarr-custom-formats-sqp-5"
     },
     {
+      "template": "radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web-german.yml",
+      "id": "radarr-custom-formats-hd-bluray-web-german"
+    },
+    {
+      "template": "radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german.yml",
+      "id": "radarr-custom-formats-uhd-bluray-web-german"
+    },
+    {
+      "template": "radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml",
+      "id": "radarr-custom-formats-uhd-remux-web-german"
+    },
+    {
       "template": "radarr/includes/quality-definitions/radarr-quality-definition-movie.yml",
       "id": "radarr-quality-definition-movie"
     },

--- a/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web-german.yml
@@ -1,0 +1,74 @@
+custom_formats:
+  - trash_ids:
+      # German Audio
+      - f845be10da4f442654c13e1f2c3d6cd5 # German DL
+    assign_scores_to:
+    - name: HD Bluray + WEB (GER)
+      score: 10001
+
+  - trash_ids:
+      # German Audio
+      - 86bc3115eb4e9873ac96904a4a68e19e # German
+      - 6aad77771dabe9d3e9d7be86f310b867 # German DL (undefined)
+
+      # German HQ Release Groups
+      - 54795711b78ea87e56127928c423689b # German Bluray Tier 01
+      - 1bfc773c53283d47c68e535811da30b7 # German Bluray Tier 02
+      - aee01d40cd1bf4bcded81ee62f0f3659 # German Bluray Tier 03
+      - a2ab25194f463f057a5559c03c84a3df # German Web Tier 01
+      - 08d120d5a003ec4954b5b255c0691d79 # German Web Tier 02
+      - 439f9d71becaed589058ec949e037ff3 # German Web Tier 03
+      - 2d136d4e33082fe573d06b1f237c40dd # German Scene
+
+      # German Unwanted
+      - 263943bc5d99550c68aad0c4278ba1c7 # German LQ
+      - 03c430f326f10a27a9739b8bc83c30e4 # German Microsized
+
+      # HQ Release Groups
+      - ed27ebfef2f323e964fb1f61391bcb35 # HD Bluray Tier 01
+      - c20c8647f2746a1f4c4262b0fbbeeeae # HD Bluray Tier 02
+      - 5608c71bcebba0a5e666223bae8c9227 # HD Bluray Tier 03
+      - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
+      - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
+      - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+
+      # Misc
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
+      - ae43b294509409a6a13919dedd4764c4 # Repack2
+      - 5caaaa1c08c1742aa4342d8c4cc463f2 # Repack3
+
+      # Unwanted
+      - ed38b889b31be83fda192888e2286d83 # BR-DISK
+      - e6886871085226c3da1830830146846c # Generated Dynamic HDR
+      - 90a6f9a284dff5103f6346090e6280c8 # LQ
+      - e204b80c87be9497a8a6eaff48f72905 # LQ (Release Title)
+      - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+      - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
+      - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+      - 0a3f082873eb454bde444150b70253cc # Extras
+      - cae4ca30163749b891686f95532519bd # AV1
+
+      # Streaming Services
+      - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
+      - 16622a6911d1ab5d5b8b713d5b0036d4 # CRiT
+      - 2a6039655313bf5dab1e43523b62c374 # MA
+    assign_scores_to:
+      - name: HD Bluray + WEB (GER)
+
+  - trash_ids:
+      # Streaming Services
+      - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
+      - 40e9380490e748672c2522eaaeb692f7 # ATVP
+      - 84272245b2988854bfb76a16e60baea5 # DSNP
+      - 509e5f41146e278f9eab1ddaceb34515 # HBO
+      - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
+      - 526d445d4c16214309f0fd2b3be18a89 # Hulu
+      - e0ec9672be6cac914ffad34a6b077209 # iT
+      - 6a061313d22e51e0f25b7cd4dc065233 # MAX
+      - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
+      - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
+      - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
+      - c2863d2a50c9acad1fb50e53ece60817 # STAN
+    assign_scores_to:
+      - name: HD Bluray + WEB (GER)
+        score: 0

--- a/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web-german.yml
@@ -3,8 +3,8 @@ custom_formats:
       # German Audio
       - f845be10da4f442654c13e1f2c3d6cd5 # German DL
     assign_scores_to:
-    - name: HD Bluray + WEB (GER)
-      score: 10001
+      - name: HD Bluray + WEB (GER)
+        score: 10001
 
   - trash_ids:
       # German Audio

--- a/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web-german.yml
@@ -71,4 +71,3 @@ custom_formats:
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
     assign_scores_to:
       - name: HD Bluray + WEB (GER)
-        score: 0

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german.yml
@@ -1,0 +1,86 @@
+custom_formats:
+  - trash_ids:
+      # German Audio
+      - f845be10da4f442654c13e1f2c3d6cd5 # German DL
+    assign_scores_to:
+    - name: HD Bluray + WEB (GER)
+      score: 10001
+
+  - trash_ids:
+      # German Audio
+      - 86bc3115eb4e9873ac96904a4a68e19e # German
+      - 6aad77771dabe9d3e9d7be86f310b867 # German DL (undefined)
+
+      # German HQ Release Groups
+      - 54795711b78ea87e56127928c423689b # German Bluray Tier 01
+      - 1bfc773c53283d47c68e535811da30b7 # German Bluray Tier 02
+      - aee01d40cd1bf4bcded81ee62f0f3659 # German Bluray Tier 03
+      - a2ab25194f463f057a5559c03c84a3df # German Web Tier 01
+      - 08d120d5a003ec4954b5b255c0691d79 # German Web Tier 02
+      - 439f9d71becaed589058ec949e037ff3 # German Web Tier 03
+      - 2d136d4e33082fe573d06b1f237c40dd # German Scene
+
+      # German Unwanted
+      - 263943bc5d99550c68aad0c4278ba1c7 # German LQ
+      - 03c430f326f10a27a9739b8bc83c30e4 # German Microsized
+      
+      # All HDR Formats
+      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
+      - e23edd2482476e595fb990b12e7c609c # DV HDR10
+      - 58d6a88f13e2db7f5059c41047876f00 # DV
+      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
+      - a3e19f8f627608af0211acd02bf89735 # DV SDR
+      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
+      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
+      - e61e28db95d22bedcadf030b8f156d96 # HDR
+      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
+      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
+      - 9364dd386c9b4a1100dde8264690add7 # HLG
+
+      # HQ Release Groups
+      - 4d74ac4c4db0b64bff6ce0cffef99bf0 # UHD Bluray Tier 01
+      - a58f517a70193f8e578056642178419d # UHD Bluray Tier 02
+      - e71939fae578037e7aed3ee219bbe7c1 # UHD Bluray Tier 03
+      - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
+      - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
+      - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+
+      # Misc
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
+      - ae43b294509409a6a13919dedd4764c4 # Repack2
+      - 5caaaa1c08c1742aa4342d8c4cc463f2 # Repack3
+
+      # Unwanted
+      - ed38b889b31be83fda192888e2286d83 # BR-DISK
+      - e6886871085226c3da1830830146846c # Generated Dynamic HDR
+      - 90a6f9a284dff5103f6346090e6280c8 # LQ
+      - e204b80c87be9497a8a6eaff48f72905 # LQ (Release Title)
+      - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+      - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
+      - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+      - 0a3f082873eb454bde444150b70253cc # Extras
+      - cae4ca30163749b891686f95532519bd # AV1
+
+      # Streaming Services
+      - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
+      - 16622a6911d1ab5d5b8b713d5b0036d4 # CRiT
+      - 2a6039655313bf5dab1e43523b62c374 # MA
+    assign_scores_to:
+      - name: UHD Bluray + WEB
+
+  - trash_ids:
+      # Streaming Services
+      - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
+      - 40e9380490e748672c2522eaaeb692f7 # ATVP
+      - 84272245b2988854bfb76a16e60baea5 # DSNP
+      - 509e5f41146e278f9eab1ddaceb34515 # HBO
+      - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
+      - 526d445d4c16214309f0fd2b3be18a89 # Hulu
+      - e0ec9672be6cac914ffad34a6b077209 # iT
+      - 6a061313d22e51e0f25b7cd4dc065233 # MAX
+      - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
+      - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
+      - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
+      - c2863d2a50c9acad1fb50e53ece60817 # STAN
+    assign_scores_to:
+      - name: UHD Bluray + WEB

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german.yml
@@ -3,8 +3,8 @@ custom_formats:
       # German Audio
       - f845be10da4f442654c13e1f2c3d6cd5 # German DL
     assign_scores_to:
-    - name: UHD Bluray + WEB (GER)
-      score: 10001
+      - name: UHD Bluray + WEB (GER)
+        score: 10001
 
   - trash_ids:
       # German Audio
@@ -23,7 +23,7 @@ custom_formats:
       # German Unwanted
       - 263943bc5d99550c68aad0c4278ba1c7 # German LQ
       - 03c430f326f10a27a9739b8bc83c30e4 # German Microsized
-      
+
       # All HDR Formats
       - c53085ddbd027d9624b320627748612f # DV HDR10Plus
       - e23edd2482476e595fb990b12e7c609c # DV HDR10

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german.yml
@@ -3,7 +3,7 @@ custom_formats:
       # German Audio
       - f845be10da4f442654c13e1f2c3d6cd5 # German DL
     assign_scores_to:
-    - name: HD Bluray + WEB (GER)
+    - name: UHD Bluray + WEB (GER)
       score: 10001
 
   - trash_ids:
@@ -66,7 +66,7 @@ custom_formats:
       - 16622a6911d1ab5d5b8b713d5b0036d4 # CRiT
       - 2a6039655313bf5dab1e43523b62c374 # MA
     assign_scores_to:
-      - name: UHD Bluray + WEB
+      - name: UHD Bluray + WEB (GER)
 
   - trash_ids:
       # Streaming Services
@@ -83,4 +83,4 @@ custom_formats:
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
     assign_scores_to:
-      - name: UHD Bluray + WEB
+      - name: UHD Bluray + WEB (GER)

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml
@@ -1,0 +1,85 @@
+custom_formats:
+  - trash_ids:
+      # German Audio
+      - f845be10da4f442654c13e1f2c3d6cd5 # German DL
+    assign_scores_to:
+    - name: HD Bluray + WEB (GER)
+      score: 10001
+
+  - trash_ids:
+      # German Audio
+      - 86bc3115eb4e9873ac96904a4a68e19e # German
+      - 6aad77771dabe9d3e9d7be86f310b867 # German DL (undefined)
+
+      # German HQ Release Groups
+      - 8608a2ed20c636b8a62de108e9147713 # German Remux Tier 01
+      - f9cf598d55ce532d63596b060a6db9ee # German Remux Tier 02
+      - a2ab25194f463f057a5559c03c84a3df # German Web Tier 01
+      - 08d120d5a003ec4954b5b255c0691d79 # German Web Tier 02
+      - 439f9d71becaed589058ec949e037ff3 # German Web Tier 03
+      - 2d136d4e33082fe573d06b1f237c40dd # German Scene
+
+      # German Unwanted
+      - 263943bc5d99550c68aad0c4278ba1c7 # German LQ
+      - 03c430f326f10a27a9739b8bc83c30e4 # German Microsized
+ 
+      # All HDR Formats
+      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
+      - e23edd2482476e595fb990b12e7c609c # DV HDR10
+      - 58d6a88f13e2db7f5059c41047876f00 # DV
+      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
+      - a3e19f8f627608af0211acd02bf89735 # DV SDR
+      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
+      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
+      - e61e28db95d22bedcadf030b8f156d96 # HDR
+      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
+      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
+      - 9364dd386c9b4a1100dde8264690add7 # HLG
+
+      # HQ Release Groups
+      - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
+      - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02
+      - 8baaf0b3142bf4d94c42a724f034e27a # Remux Tier 03
+      - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
+      - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
+      - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+
+      # Misc
+      - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
+      - ae43b294509409a6a13919dedd4764c4 # Repack2
+      - 5caaaa1c08c1742aa4342d8c4cc463f2 # Repack3
+
+      # Unwanted
+      - ed38b889b31be83fda192888e2286d83 # BR-DISK
+      - e6886871085226c3da1830830146846c # Generated Dynamic HDR
+      - 90a6f9a284dff5103f6346090e6280c8 # LQ
+      - e204b80c87be9497a8a6eaff48f72905 # LQ (Release Title)
+      - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+      - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
+      - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+      - 0a3f082873eb454bde444150b70253cc # Extras
+      - cae4ca30163749b891686f95532519bd # AV1
+
+      # Streaming Services
+      - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
+      - 16622a6911d1ab5d5b8b713d5b0036d4 # CRiT
+      - 2a6039655313bf5dab1e43523b62c374 # MA
+    assign_scores_to:
+      - name: Remux + WEB 2160p
+
+  - trash_ids:
+      # Streaming Services
+      - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
+      - 40e9380490e748672c2522eaaeb692f7 # ATVP
+      - 84272245b2988854bfb76a16e60baea5 # DSNP
+      - 509e5f41146e278f9eab1ddaceb34515 # HBO
+      - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
+      - 526d445d4c16214309f0fd2b3be18a89 # Hulu
+      - e0ec9672be6cac914ffad34a6b077209 # iT
+      - 6a061313d22e51e0f25b7cd4dc065233 # MAX
+      - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
+      - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
+      - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
+      - c2863d2a50c9acad1fb50e53ece60817 # STAN
+    assign_scores_to:
+      - name: Remux + WEB 2160p

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml
@@ -3,8 +3,8 @@ custom_formats:
       # German Audio
       - f845be10da4f442654c13e1f2c3d6cd5 # German DL
     assign_scores_to:
-    - name: Remux + WEB 2160p (GER)
-      score: 10001
+      - name: Remux + WEB 2160p (GER)
+        score: 10001
 
   - trash_ids:
       # German Audio
@@ -22,7 +22,7 @@ custom_formats:
       # German Unwanted
       - 263943bc5d99550c68aad0c4278ba1c7 # German LQ
       - 03c430f326f10a27a9739b8bc83c30e4 # German Microsized
- 
+
       # All HDR Formats
       - c53085ddbd027d9624b320627748612f # DV HDR10Plus
       - e23edd2482476e595fb990b12e7c609c # DV HDR10

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml
@@ -3,7 +3,7 @@ custom_formats:
       # German Audio
       - f845be10da4f442654c13e1f2c3d6cd5 # German DL
     assign_scores_to:
-    - name: HD Bluray + WEB (GER)
+    - name: Remux + WEB 2160p (GER)
       score: 10001
 
   - trash_ids:
@@ -65,7 +65,7 @@ custom_formats:
       - 16622a6911d1ab5d5b8b713d5b0036d4 # CRiT
       - 2a6039655313bf5dab1e43523b62c374 # MA
     assign_scores_to:
-      - name: Remux + WEB 2160p
+      - name: Remux + WEB 2160p (GER)
 
   - trash_ids:
       # Streaming Services
@@ -82,4 +82,4 @@ custom_formats:
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
     assign_scores_to:
-      - name: Remux + WEB 2160p
+      - name: Remux + WEB 2160p (GER)


### PR DESCRIPTION
Added three templates based on the international ones for the CFs for the German Guide.