### PR TITLE
fix: adapt templates for german guide to fully cover the written guide

### DIFF
--- a/includes.json
+++ b/includes.json
@@ -105,6 +105,10 @@
       "id": "radarr-custom-formats-uhd-bluray-web-german"
     },
     {
+      "template": "radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german-alternative.yml",
+      "id": "radarr-custom-formats-uhd-bluray-web-german-alternative"
+    },
+    {
       "template": "radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml",
       "id": "radarr-custom-formats-uhd-remux-web-german"
     },

--- a/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web-german.yml
@@ -47,6 +47,7 @@ custom_formats:
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
       - 0a3f082873eb454bde444150b70253cc # Extras
       - cae4ca30163749b891686f95532519bd # AV1
+      - c465ccc73923871b3eb1802042331306 # Line/Mic Dubbed
 
       # Streaming Services
       - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german-alternative.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german-alternative.yml
@@ -3,7 +3,7 @@ custom_formats:
       # German Audio
       - f845be10da4f442654c13e1f2c3d6cd5 # German DL
     assign_scores_to:
-      - name: UHD Bluray + WEB (GER)
+      - name: UHD Bluray + WEB (GER) (Alternative)
         score: 10001
 
   - trash_ids:
@@ -41,6 +41,9 @@ custom_formats:
       - 4d74ac4c4db0b64bff6ce0cffef99bf0 # UHD Bluray Tier 01
       - a58f517a70193f8e578056642178419d # UHD Bluray Tier 02
       - e71939fae578037e7aed3ee219bbe7c1 # UHD Bluray Tier 03
+      - ed27ebfef2f323e964fb1f61391bcb35 # HD Bluray Tier 01
+      - c20c8647f2746a1f4c4262b0fbbeeeae # HD Bluray Tier 02
+      - 5608c71bcebba0a5e666223bae8c9227 # HD Bluray Tier 03
       - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
       - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
       - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
@@ -91,4 +94,4 @@ custom_formats:
       - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
     assign_scores_to:
-      - name: UHD Bluray + WEB (GER)
+      - name: UHD Bluray + WEB (GER) (Alternative)

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german-alternative.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german-alternative.yml
@@ -77,7 +77,7 @@ custom_formats:
       - 16622a6911d1ab5d5b8b713d5b0036d4 # CRiT
       - 2a6039655313bf5dab1e43523b62c374 # MA
     assign_scores_to:
-      - name: UHD Bluray + WEB (GER)
+      - name: UHD Bluray + WEB (GER) (Alternative)
 
   - trash_ids:
       # Streaming Services

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml
@@ -49,6 +49,13 @@ custom_formats:
       - ae43b294509409a6a13919dedd4764c4 # Repack2
       - 5caaaa1c08c1742aa4342d8c4cc463f2 # Repack3
 
+      # Resolution
+      - 3bc8df3a71baaac60a31ef696ea72d36 # German 1080p Booster
+      - cc7b1e64e2513a6a271090cdfafaeb55 # German 2160p Booster
+      - b2be17d608fc88818940cd1833b0b24c # 720p
+      - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
+      - fb392fb0d61a010ae38e49ceaa24a1ef # 2160p
+
       # Unwanted
       - ed38b889b31be83fda192888e2286d83 # BR-DISK
       - e6886871085226c3da1830830146846c # Generated Dynamic HDR
@@ -59,6 +66,7 @@ custom_formats:
       - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
       - 0a3f082873eb454bde444150b70253cc # Extras
       - cae4ca30163749b891686f95532519bd # AV1
+      - c465ccc73923871b3eb1802042331306 # Line/Mic Dubbed
 
       # Streaming Services
       - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -32,11 +32,7 @@ radarr:
         quality_sort: top
         qualities:
           - name: Merged QPs
-# Comment any qualities you are not interested in
             qualities:
-#              - Bluray-2160p
-#              - WEBDL-2160p
-#              - WEBRip-2160p
               - Bluray-1080p
               - WEBRip-1080p
               - WEBDL-1080p
@@ -57,14 +53,27 @@ radarr:
         assign_scores_to:
           - name: HD Bluray + WEB (GER)
 
+### Movie Versions
+      - trash_ids:
+# Uncomment any of the following lines to prefer these movie versions
+#          - 570bc9ebecd92723d2d21500f4be314c # Remaster
+#          - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
+#          - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
+#          - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
+#          - db9b4c4b53d312a3ca5f1378f6440fc9 # Vinegar Syndrome
+#          - 957d0f44b592285f26449575e8b1167e # Special Edition
+#          - eecf3a857724171f968a66cb5719e152 # IMAX
+#          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+        assign_scores_to:
+          - name: HD Bluray + WEB (GER)
+
+
 ### Resolution Boosters
 # Uncomment any ID corresponding to resolutions you are not interested in
       - trash_ids:
           - 3bc8df3a71baaac60a31ef696ea72d36 # German 1080p Booster
-          - cc7b1e64e2513a6a271090cdfafaeb55 # German 2160p Booster
           - b2be17d608fc88818940cd1833b0b24c # 720p
           - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
-          - fb392fb0d61a010ae38e49ceaa24a1ef # 2160p
         assign_scores_to:
           - name: HD Bluray + WEB (GER)
 
@@ -78,11 +87,13 @@ radarr:
 
 ### x265 Releases
       - trash_ids:
-# Uncomment the next six lines to allow x265 HD releases with HDR/DV
-# Uncomment the next four lines to allow any x265 HD releases
-#          - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
-#        assign_scores_to:
-#          - name: HD Bluray + WEB (GER)
-#            score: 0
-#      - trash_ids:
+# Uncomment the next line to allow x265 HD releases with HDR/DV
 #          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+        assign_scores_to:
+          - name: HD Bluray + WEB (GER)
+      - trash_ids:
+# Uncomment the next line to allow any x265 HD releases
+#          - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+        assign_scores_to:
+          - name: HD Bluray + WEB (GER)
+            score: 0

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2024-12-29                                                                             #
+# Updated: 2024-12-31                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/radarr/templates/german-uhd-bluray-web-alternative.yml
@@ -97,7 +97,7 @@ radarr:
 #      - trash_ids:
 #          - e6886871085226c3da1830830146846c # Generated Dynamic HDR
 #        assign_scores_to:
-#          - name: UHD Bluray + WEB (GER)
+#          - name: UHD Bluray + WEB (GER) (Alternative)
 #            score: 0
 
 ### x265 Releases

--- a/radarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/radarr/templates/german-uhd-bluray-web-alternative.yml
@@ -10,16 +10,16 @@
 # Instance Definition: https://recyclarr.dev/wiki/yaml/config-reference/basic/
 
 radarr:
-  uhd-bluray-web-ger:
+  uhd-bluray-web-ger-alternative:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
     include:
       - template: radarr-quality-definition-movie
-      - template: radarr-custom-formats-uhd-bluray-web-german
+      - template: radarr-custom-formats-uhd-bluray-web-german-alternative
 
     quality_profiles:
-      - name: UHD Bluray + WEB (GER)
+      - name: UHD Bluray + WEB (GER) (Alternative)
         reset_unmatched_scores:
           enabled: false
         upgrade:
@@ -37,6 +37,12 @@ radarr:
               - Bluray-2160p
               - WEBDL-2160p
               - WEBRip-2160p
+              - Bluray-1080p
+              - WEBRip-1080p
+              - WEBDL-1080p
+              - Bluray-720p
+              - WEBDL-720p
+              - WEBRip-720p
 
     custom_formats:
 
@@ -58,7 +64,7 @@ radarr:
 #          - 240770601cc226190c367ef59aba7463 # AAC
 #          - c2998bd0d90ed5621d8df281e839436e # DD
         assign_scores_to:
-          - name: UHD Bluray + WEB (GER)
+          - name: UHD Bluray + WEB (GER) (Alternative)
 
 ### Movie Versions
       - trash_ids:
@@ -73,7 +79,7 @@ radarr:
 #          - eecf3a857724171f968a66cb5719e152 # IMAX
 #          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
         assign_scores_to:
-          - name: UHD Bluray + WEB (GER)
+          - name: UHD Bluray + WEB (GER) (Alternative)
 
 ### Optional
       - trash_ids:
@@ -84,7 +90,7 @@ radarr:
 #          - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
 #          - f537cf427b64c38c8e36298f657e4828 # Scene
         assign_scores_to:
-          - name: UHD Bluray + WEB (GER)
+          - name: UHD Bluray + WEB (GER) (Alternative)
 
 ### Generated Dynamic HDR
 # Uncomment the next 5 lines if you dont care about Generated Dynamic HDR and/or want to grab VECTOR
@@ -99,12 +105,12 @@ radarr:
 # Uncomment the next line to allow x265 HD releases with HDR/DV
 #          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
         assign_scores_to:
-          - name: UHD Bluray + WEB (GER)
+          - name: UHD Bluray + WEB (GER) (Alternative)
       - trash_ids:
 # Uncomment the next line to allow any x265 HD releases
 #          - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
         assign_scores_to:
-          - name: UHD Bluray + WEB (GER)
+          - name: UHD Bluray + WEB (GER) (Alternative)
             score: 0
 
 ### HDR / DV
@@ -116,7 +122,7 @@ radarr:
 #          - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
 #          - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
         assign_scores_to:
-          - name: UHD Bluray + WEB (GER)
+          - name: UHD Bluray + WEB (GER) (Alternative)
 
 ### Optional SDR
 # Only ever use ONE of the following custom formats:
@@ -126,4 +132,4 @@ radarr:
 #          - 9c38ebb7384dada637be8899efa68e6f # SDR
 #          - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)
         assign_scores_to:
-          - name: UHD Bluray + WEB (GER)
+          - name: UHD Bluray + WEB (GER) (Alternative)

--- a/radarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/radarr/templates/german-uhd-bluray-web-alternative.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2024-12-29                                                                             #
+# Updated: 2024-12-31                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2024-12-29                                                                             #
+# Updated: 2024-12-31                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -35,15 +35,8 @@ radarr:
 # Comment any qualities you are not interested in
             qualities:
               - Remux-2160p
-#              - Bluray-2160p
               - WEBDL-2160p
               - WEBRip-2160p
-#              - Bluray-1080p
-#              - WEBRip-1080p
-#              - WEBDL-1080p
-#              - Bluray-720p
-#              - WEBDL-720p
-#              - WEBRip-720p
 
     custom_formats:
 
@@ -70,6 +63,7 @@ radarr:
 ### Movie Versions
       - trash_ids:
 # Uncomment any of the following lines to prefer these movie versions
+#          - 0f12c086e289cf966fa5948eac571f44 # Hybrid
 #          - 570bc9ebecd92723d2d21500f4be314c # Remaster
 #          - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
 #          - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
@@ -80,6 +74,7 @@ radarr:
 #          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
         assign_scores_to:
           - name: Remux + WEB 2160p (GER)
+
 ### Optional
       - trash_ids:
 #          - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
@@ -88,17 +83,6 @@ radarr:
 #          - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
 #          - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
 #          - f537cf427b64c38c8e36298f657e4828 # Scene
-        assign_scores_to:
-          - name: Remux + WEB 2160p (GER)
-
-### Resolution Boosters
-# Comment any ID corresponding to resolutions you are not interested in
-      - trash_ids:
-          - 3bc8df3a71baaac60a31ef696ea72d36 # German 1080p Booster
-          - cc7b1e64e2513a6a271090cdfafaeb55 # German 2160p Booster
-          - b2be17d608fc88818940cd1833b0b24c # 720p
-          - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
-          - fb392fb0d61a010ae38e49ceaa24a1ef # 2160p
         assign_scores_to:
           - name: Remux + WEB 2160p (GER)
 
@@ -112,14 +96,16 @@ radarr:
 
 ### x265 Releases
       - trash_ids:
-# Uncomment the next six lines to allow x265 HD releases with HDR/DV
-# Uncomment the next four lines to allow any x265 HD releases
-#          - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
-#        assign_scores_to:
-#          - name: Remux + WEB 2160p (GER)
-#            score: 0
-#      - trash_ids:
+# Uncomment the next line to allow x265 HD releases with HDR/DV
 #          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
+        assign_scores_to:
+          - name: Remux + WEB 2160p (GER)
+      - trash_ids:
+# Uncomment the next line to allow any x265 HD releases
+#          - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+        assign_scores_to:
+          - name: Remux + WEB 2160p (GER)
+            score: 0
 
 ### HDR / DV
       - trash_ids:

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2024-12-29                                                                             #
+# Updated: 2024-12-31                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/templates.json
+++ b/templates.json
@@ -45,6 +45,10 @@
       "id": "german-uhd-bluray-web"
     },
     {
+      "template": "radarr/templates/german-uhd-bluray-web-alternative.yml",
+      "id": "german-uhd-bluray-web-alternative"
+    },
+    {
       "template": "radarr/templates/german-uhd-remux-web.yml",
       "id": "german-uhd-remux-web"
     },


### PR DESCRIPTION
We want the templates to be 100% in sync with the written guide, so we adapted the templates for the german guide to achieve this.