### PR TITLE
fix: German Guide templates - another typo in the include.json

### DIFF
--- a/includes.json
+++ b/includes.json
@@ -229,15 +229,15 @@
       "id": "radarr-quality-profile-sqp-5"
     },
     {
-      "template": "radarr/includes/quality-profiles/radarr-custom-formats-hd-bluray-web-german.yml",
+      "template": "radarr/includes/quality-profiles/radarr-quality-profile-hd-bluray-web-german.yml",
       "id": "radarr-quality-profile-hd-bluray-web-german"
     },
     {
-      "template": "radarr/includes/quality-profiles/radarr-custom-formats-uhd-bluray-web-german.yml",
+      "template": "radarr/includes/quality-profiles/radarr-quality-profile-uhd-bluray-web-german.yml",
       "id": "radarr-quality-profile-uhd-bluray-web-german"
     },
     {
-      "template": "radarr/includes/quality-profiles/radarr-custom-formats-uhd-remux-web-german.yml",
+      "template": "radarr/includes/quality-profiles/radarr-quality-profile-uhd-remux-web-german.yml",
       "id": "radarr-quality-profile-uhd-remux-web-german"
     }
   ],


### PR DESCRIPTION
Another typo, fixing problems while at work with other things is not a good idea :( 