### PR TITLE
Fix: German Guide templates - wrong reference in top level templates

### DIFF
--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2025-01-09                                                                            #
+# Updated: 2025-01-10                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -108,13 +108,13 @@ radarr:
       - trash_ids:
 #          - 839bea857ed2c0a8e084f3cbdbd65ecb # Uncomment this line to allow HDR/DV x265 HD releases
         assign_scores_to:
-          - name: HD Bluray + WEB (GER)
+          - name: UHD Bluray + WEB (GER)
 
       - trash_ids:
 #          - dc98083864ea246d05a42df0d05f81cc # Uncomment this line to allow any x265 HD releases
 #          - e6886871085226c3da1830830146846c # Uncomment this line to allow Generated Dynamic HDR
         assign_scores_to:
-          - name: HD Bluray + WEB (GER)
+          - name: UHD Bluray + WEB (GER)
             score: 0
 
 ### Alternative Quality Profile (upgrades 720p > 1080p > 2160p)

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -118,7 +118,7 @@ radarr:
             score: 0
 
 ### Alternative Quality Profile (upgrades 720p > 1080p > 2160p)
-# Uncomment the next 6 lines to use the alternative quality profile
+# Uncomment the next 6 lines to use the alternative quality profile with english releases
 #      - trash_ids:
 #          - ed27ebfef2f323e964fb1f61391bcb35 # HD Bluray Tier 01
 #          - c20c8647f2746a1f4c4262b0fbbeeeae # HD Bluray Tier 02

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2025-01-09                                                                             #
+# Updated: 2025-01-10                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2025-01-09                                                                           #
+# Updated: 2025-01-10                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -94,11 +94,11 @@ radarr:
       - trash_ids:
 #          - 839bea857ed2c0a8e084f3cbdbd65ecb # Uncomment this line to allow HDR/DV x265 HD releases
         assign_scores_to:
-          - name: HD Bluray + WEB (GER)
+          - name: Remux + WEB 2160p (GER)
 
       - trash_ids:
 #          - dc98083864ea246d05a42df0d05f81cc # Uncomment this line to allow any x265 HD releases
 #          - e6886871085226c3da1830830146846c # Uncomment this line to allow Generated Dynamic HDR
         assign_scores_to:
-          - name: HD Bluray + WEB (GER)
+          - name: Remux + WEB 2160p (GER)
             score: 0


### PR DESCRIPTION
The UHD and Remux top level templates were wrongly referencing the HD quality profiles.