### PR TITLE
Fix: add not english or german CF, maximum score adjustments and introduce the german score_set for the german radarr profiles 

### DIFF
--- a/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web-german.yml
@@ -1,15 +1,10 @@
 custom_formats:
   - trash_ids:
       # German Audio
-      - f845be10da4f442654c13e1f2c3d6cd5 # German DL
-    assign_scores_to:
-      - name: HD Bluray + WEB (GER)
-        score: 10001
-
-  - trash_ids:
-      # German Audio
       - 86bc3115eb4e9873ac96904a4a68e19e # German
       - 6aad77771dabe9d3e9d7be86f310b867 # German DL (undefined)
+      - f845be10da4f442654c13e1f2c3d6cd5 # German DL
+      - 4eadb75fb23d09dfc0a8e3f687e72287 # Not German or English
 
       # German HQ Release Groups
       - 54795711b78ea87e56127928c423689b # German Bluray Tier 01

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german.yml
@@ -1,15 +1,10 @@
 custom_formats:
   - trash_ids:
       # German Audio
-      - f845be10da4f442654c13e1f2c3d6cd5 # German DL
-    assign_scores_to:
-      - name: UHD Bluray + WEB (GER)
-        score: 10001
-
-  - trash_ids:
-      # German Audio
       - 86bc3115eb4e9873ac96904a4a68e19e # German
       - 6aad77771dabe9d3e9d7be86f310b867 # German DL (undefined)
+      - f845be10da4f442654c13e1f2c3d6cd5 # German DL
+      - 4eadb75fb23d09dfc0a8e3f687e72287 # Not German or English
 
       # German HQ Release Groups
       - 54795711b78ea87e56127928c423689b # German Bluray Tier 01

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml
@@ -1,15 +1,10 @@
 custom_formats:
   - trash_ids:
       # German Audio
-      - f845be10da4f442654c13e1f2c3d6cd5 # German DL
-    assign_scores_to:
-      - name: Remux + WEB 2160p (GER)
-        score: 10001
-
-  - trash_ids:
-      # German Audio
       - 86bc3115eb4e9873ac96904a4a68e19e # German
       - 6aad77771dabe9d3e9d7be86f310b867 # German DL (undefined)
+      - f845be10da4f442654c13e1f2c3d6cd5 # German DL
+      - 4eadb75fb23d09dfc0a8e3f687e72287 # Not German or English
 
       # German HQ Release Groups
       - 8608a2ed20c636b8a62de108e9147713 # German Remux Tier 01

--- a/radarr/includes/quality-profiles/radarr-quality-profile-hd-bluray-web-german.yml
+++ b/radarr/includes/quality-profiles/radarr-quality-profile-hd-bluray-web-german.yml
@@ -2,6 +2,7 @@ quality_profiles:
   - name: HD Bluray + WEB (GER)
     reset_unmatched_scores:
       enabled: false
+    score_set: german
     upgrade:
       allowed: true
       until_quality: Merged QPs

--- a/radarr/includes/quality-profiles/radarr-quality-profile-hd-bluray-web-german.yml
+++ b/radarr/includes/quality-profiles/radarr-quality-profile-hd-bluray-web-german.yml
@@ -6,7 +6,7 @@ quality_profiles:
     upgrade:
       allowed: true
       until_quality: Merged QPs
-      until_score: 25000
+      until_score: 35000
     min_format_score: 0
     quality_sort: top
     qualities:

--- a/radarr/includes/quality-profiles/radarr-quality-profile-uhd-bluray-web-german.yml
+++ b/radarr/includes/quality-profiles/radarr-quality-profile-uhd-bluray-web-german.yml
@@ -2,6 +2,7 @@ quality_profiles:
   - name: UHD Bluray + WEB (GER)
     reset_unmatched_scores:
       enabled: false
+    score_set: german
     upgrade:
       allowed: true
       until_quality: Merged QPs

--- a/radarr/includes/quality-profiles/radarr-quality-profile-uhd-bluray-web-german.yml
+++ b/radarr/includes/quality-profiles/radarr-quality-profile-uhd-bluray-web-german.yml
@@ -6,7 +6,7 @@ quality_profiles:
     upgrade:
       allowed: true
       until_quality: Merged QPs
-      until_score: 25000
+      until_score: 35000
     min_format_score: 0
     quality_sort: top
     qualities:

--- a/radarr/includes/quality-profiles/radarr-quality-profile-uhd-remux-web-german.yml
+++ b/radarr/includes/quality-profiles/radarr-quality-profile-uhd-remux-web-german.yml
@@ -2,6 +2,7 @@ quality_profiles:
   - name: Remux + WEB 2160p (GER)
     reset_unmatched_scores:
       enabled: false
+    score_set: german
     upgrade:
       allowed: true
       until_quality: Merged QPs

--- a/radarr/includes/quality-profiles/radarr-quality-profile-uhd-remux-web-german.yml
+++ b/radarr/includes/quality-profiles/radarr-quality-profile-uhd-remux-web-german.yml
@@ -6,7 +6,7 @@ quality_profiles:
     upgrade:
       allowed: true
       until_quality: Merged QPs
-      until_score: 25000
+      until_score: 35000
     min_format_score: 0
     quality_sort: top
     qualities:

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2025-01-16                                                                             #
+# Updated: 2025-01-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -48,15 +48,21 @@ radarr:
         assign_scores_to:
           - name: HD Bluray + WEB (GER)
 
-### Others
+### x265 - IMPORTANT: Only use on of the options below.
       - trash_ids:
 #          - 839bea857ed2c0a8e084f3cbdbd65ecb # Uncomment this line to allow HDR/DV x265 HD releases
         assign_scores_to:
           - name: HD Bluray + WEB (GER)
 
       - trash_ids:
-#          - dc98083864ea246d05a42df0d05f81cc # Uncomment this line to allow any x265 HD releases
-#          - e6886871085226c3da1830830146846c # Uncomment this line to allow Generated Dynamic HDR
+#          - dc98083864ea246d05a42df0d05f81cc # Uncomment this line to block all x265 HD releases
         assign_scores_to:
           - name: HD Bluray + WEB (GER)
-            score: 0
+            score: -30000
+
+### Generated Dynamic HDR
+      - trash_ids:
+#          - e6886871085226c3da1830830146846c # Uncomment this line to block Generated Dynamic HDR
+        assign_scores_to:
+          - name: HD Bluray + WEB (GER)
+            score: -30000

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2025-01-10                                                                             #
+# Updated: 2025-01-16                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -58,11 +58,11 @@ radarr:
 #          - dc98083864ea246d05a42df0d05f81cc # Uncomment this line to block all x265 HD releases
         assign_scores_to:
           - name: HD Bluray + WEB (GER)
-            score: -30000
+            score: -35000
 
 ### Generated Dynamic HDR
       - trash_ids:
 #          - e6886871085226c3da1830830146846c # Uncomment this line to block Generated Dynamic HDR
         assign_scores_to:
           - name: HD Bluray + WEB (GER)
-            score: -30000
+            score: -35000

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -104,18 +104,24 @@ radarr:
         assign_scores_to:
           - name: UHD Bluray + WEB (GER)
 
-### Others
+### x265 - IMPORTANT: Only use on of the options below.
       - trash_ids:
 #          - 839bea857ed2c0a8e084f3cbdbd65ecb # Uncomment this line to allow HDR/DV x265 HD releases
         assign_scores_to:
           - name: UHD Bluray + WEB (GER)
 
       - trash_ids:
-#          - dc98083864ea246d05a42df0d05f81cc # Uncomment this line to allow any x265 HD releases
-#          - e6886871085226c3da1830830146846c # Uncomment this line to allow Generated Dynamic HDR
+#          - dc98083864ea246d05a42df0d05f81cc # Uncomment this line to block all x265 HD releases
         assign_scores_to:
           - name: UHD Bluray + WEB (GER)
-            score: 0
+            score: -30000
+
+### Generated Dynamic HDR
+      - trash_ids:
+#          - e6886871085226c3da1830830146846c # Uncomment this line to block Generated Dynamic HDR
+        assign_scores_to:
+          - name: UHD Bluray + WEB (GER)
+            score: -30000
 
 ### Alternative Quality Profile (upgrades 720p > 1080p > 2160p)
 # Uncomment the next 6 lines to use the alternative quality profile with english releases

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -86,7 +86,7 @@ radarr:
 ### HDR / DV
       - trash_ids:
 # Comment out the next line if you and all of your users' setups are fully DV compatible
-#          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
 
 # HDR10+ Boost - Uncomment the next two lines if any of your devices DO support HDR10+
 #          - b17886cb4158d9fea189859409975758 # HDR10Plus Boost

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB (GER)                                        #
-# Updated: 2025-01-16                                                                             #
+# Updated: 2025-01-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
-# Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2025-01-10                                                                             #
+# Recyclarr Configuration Template: UHD Bluray + WEB (GER)                                        #
+# Updated: 2025-01-16                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -114,14 +114,14 @@ radarr:
 #          - dc98083864ea246d05a42df0d05f81cc # Uncomment this line to block all x265 HD releases
         assign_scores_to:
           - name: UHD Bluray + WEB (GER)
-            score: -30000
+            score: -35000
 
 ### Generated Dynamic HDR
       - trash_ids:
 #          - e6886871085226c3da1830830146846c # Uncomment this line to block Generated Dynamic HDR
         assign_scores_to:
           - name: UHD Bluray + WEB (GER)
-            score: -30000
+            score: -35000
 
 ### Alternative Quality Profile (upgrades 720p > 1080p > 2160p)
 # Uncomment the next 6 lines to use the alternative quality profile with english releases

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -72,7 +72,7 @@ radarr:
 ### HDR / DV
       - trash_ids:
 # Comment out the next line if you and all of your users' setups are fully DV compatible
-#          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
 
 # HDR10+ Boost - Uncomment the next two lines if any of your devices DO support HDR10+
 #          - b17886cb4158d9fea189859409975758 # HDR10Plus Boost

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -90,15 +90,21 @@ radarr:
         assign_scores_to:
           - name: Remux + WEB 2160p (GER)
 
-### Others
+### x265 - IMPORTANT: Only use on of the options below.
       - trash_ids:
 #          - 839bea857ed2c0a8e084f3cbdbd65ecb # Uncomment this line to allow HDR/DV x265 HD releases
         assign_scores_to:
           - name: Remux + WEB 2160p (GER)
 
       - trash_ids:
-#          - dc98083864ea246d05a42df0d05f81cc # Uncomment this line to allow any x265 HD releases
-#          - e6886871085226c3da1830830146846c # Uncomment this line to allow Generated Dynamic HDR
+#          - dc98083864ea246d05a42df0d05f81cc # Uncomment this line to block all x265 HD releases
         assign_scores_to:
           - name: Remux + WEB 2160p (GER)
-            score: 0
+            score: -30000
+
+### Generated Dynamic HDR
+      - trash_ids:
+#          - e6886871085226c3da1830830146846c # Uncomment this line to block Generated Dynamic HDR
+        assign_scores_to:
+          - name: Remux + WEB 2160p (GER)
+            score: -30000

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
-# Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2025-01-10                                                                             #
+# Recyclarr Configuration Template: UHD Remux + WEB (GER)                                         #
+# Updated: 2025-01-16                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -100,11 +100,11 @@ radarr:
 #          - dc98083864ea246d05a42df0d05f81cc # Uncomment this line to block all x265 HD releases
         assign_scores_to:
           - name: Remux + WEB 2160p (GER)
-            score: -30000
+            score: -35000
 
 ### Generated Dynamic HDR
       - trash_ids:
 #          - e6886871085226c3da1830830146846c # Uncomment this line to block Generated Dynamic HDR
         assign_scores_to:
           - name: Remux + WEB 2160p (GER)
-            score: -30000
+            score: -35000

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Remux + WEB (GER)                                         #
-# Updated: 2025-01-16                                                                             #
+# Updated: 2025-01-18                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #


### PR DESCRIPTION
- Add the not english or german CF to the profiles.
- Adapt the maximum score to be more than the actual maximum score, increase penalties in profiles for blockers to reflect that (penalties in the CFs itself will be adjusted for the german guide soon as well)
- Set the german score_set to always take the german scores.