### PR TITLE
fix: make sonarr template names unique for the german guide

### DIFF
--- a/sonarr/templates/german-hd-bluray-web-v4.yml
+++ b/sonarr/templates/german-hd-bluray-web-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2025-01-17                                                                             #
+# Updated: 2025-01-20                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/sonarr/templates/german-hd-remux-web-v4.yml
+++ b/sonarr/templates/german-hd-remux-web-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Remux + WEB (GER)                                          #
-# Updated: 2025-01-17                                                                             #
+# Updated: 2025-01-20                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/sonarr/templates/german-uhd-bluray-web-v4.yml
+++ b/sonarr/templates/german-uhd-bluray-web-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB (GER)                                        #
-# Updated: 2025-01-17                                                                             #
+# Updated: 2025-01-20                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/sonarr/templates/german-uhd-remux-web-v4.yml
+++ b/sonarr/templates/german-uhd-remux-web-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Remux + WEB (GER)                                         #
-# Updated: 2025-01-17                                                                             #
+# Updated: 2025-01-20                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #

--- a/templates.json
+++ b/templates.json
@@ -110,20 +110,20 @@
       "id": "french-anime-1080p-v4"
     },
     {
-      "template": "sonarr/templates/german-hd-bluray-web.yml",
-      "id": "german-hd-bluray-web"
+      "template": "sonarr/templates/german-hd-bluray-web-v4.yml",
+      "id": "german-hd-bluray-web-v4"
     },
     {
-      "template": "sonarr/templates/german-hd-remux-web.yml",
-      "id": "german-hd-remux-web"
+      "template": "sonarr/templates/german-hd-remux-web-v4.yml",
+      "id": "german-hd-remux-web-v4"
     },
     {
-      "template": "sonarr/templates/german-uhd-bluray-web.yml",
-      "id": "german-uhd-bluray-web"
+      "template": "sonarr/templates/german-uhd-bluray-web-v4.yml",
+      "id": "german-uhd-bluray-web-v4"
     },
     {
-      "template": "sonarr/templates/german-uhd-remux-web.yml",
-      "id": "german-uhd-remux-web"
+      "template": "sonarr/templates/german-uhd-remux-web-v4.yml",
+      "id": "german-uhd-remux-web-v4"
     }
   ]
 }


### PR DESCRIPTION
As apparently when using `recyclarr config create -t` the command only looks at the name of the template - the templates names across sonarr and radarr should be unique.

Thats why we updated the sonarr template names.