### PR TITLE
Fix: remove international Scene CF for german templates

### DIFF
--- a/radarr/includes/quality-profiles/radarr-quality-profile-hd-bluray-web-german.yml
+++ b/radarr/includes/quality-profiles/radarr-quality-profile-hd-bluray-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: HD Bluray + WEB (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true

--- a/radarr/includes/quality-profiles/radarr-quality-profile-uhd-bluray-web-german.yml
+++ b/radarr/includes/quality-profiles/radarr-quality-profile-uhd-bluray-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: UHD Bluray + WEB (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true

--- a/radarr/includes/quality-profiles/radarr-quality-profile-uhd-remux-web-german.yml
+++ b/radarr/includes/quality-profiles/radarr-quality-profile-uhd-remux-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: Remux + WEB 2160p (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2025-01-18                                                                             #
+# Updated: 2025-01-26                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -30,7 +30,6 @@ radarr:
 #          - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
 #          - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
 #          - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
-#          - f537cf427b64c38c8e36298f657e4828 # Scene
         assign_scores_to:
           - name: HD Bluray + WEB (GER)
 

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB (GER)                                        #
-# Updated: 2025-01-18                                                                             #
+# Updated: 2025-01-26                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -79,7 +79,6 @@ radarr:
 #          - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
 #          - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
 #          - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
-#          - f537cf427b64c38c8e36298f657e4828 # Scene
         assign_scores_to:
           - name: UHD Bluray + WEB (GER)
 

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Remux + WEB (GER)                                         #
-# Updated: 2025-01-18                                                                             #
+# Updated: 2025-01-26                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -65,7 +65,6 @@ radarr:
 #          - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
 #          - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
 #          - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
-#          - f537cf427b64c38c8e36298f657e4828 # Scene
         assign_scores_to:
           - name: Remux + WEB 2160p (GER)
 

--- a/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-hd-bluray-web-german.yml
+++ b/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-hd-bluray-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: HD Bluray + WEB (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true

--- a/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-hd-remux-web-german.yml
+++ b/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-hd-remux-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: HD Remux + WEB (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true

--- a/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-uhd-bluray-web-german.yml
+++ b/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-uhd-bluray-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: UHD Bluray + WEB (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true

--- a/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-uhd-remux-web-german.yml
+++ b/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-uhd-remux-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: UHD Remux + WEB (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true

--- a/sonarr/templates/german-hd-bluray-web-v4.yml
+++ b/sonarr/templates/german-hd-bluray-web-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2025-01-20                                                                             #
+# Updated: 2025-01-26                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -29,7 +29,6 @@ sonarr:
 #          - 82d40da2bc6923f41e14394075dd4b03 # No-RlsGroup
 #          - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
 #          - 06d66ab109d4d2eddb2794d21526d140 # Retags
-#          - 1b3994c551cbb92a2c781af061f4ab44 # Scene
         assign_scores_to:
           - name: HD Bluray + WEB (GER)
 

--- a/sonarr/templates/german-hd-remux-web-v4.yml
+++ b/sonarr/templates/german-hd-remux-web-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Remux + WEB (GER)                                          #
-# Updated: 2025-01-20                                                                             #
+# Updated: 2025-01-26                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -29,7 +29,6 @@ sonarr:
 #          - 82d40da2bc6923f41e14394075dd4b03 # No-RlsGroup
 #          - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
 #          - 06d66ab109d4d2eddb2794d21526d140 # Retags
-#          - 1b3994c551cbb92a2c781af061f4ab44 # Scene
         assign_scores_to:
           - name: HD Remux + WEB (GER)
 

--- a/sonarr/templates/german-uhd-bluray-web-v4.yml
+++ b/sonarr/templates/german-uhd-bluray-web-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB (GER)                                        #
-# Updated: 2025-01-20                                                                             #
+# Updated: 2025-01-26                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -43,7 +43,6 @@ sonarr:
 #          - 82d40da2bc6923f41e14394075dd4b03 # No-RlsGroup
 #          - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
 #          - 06d66ab109d4d2eddb2794d21526d140 # Retags
-#          - 1b3994c551cbb92a2c781af061f4ab44 # Scene
         assign_scores_to:
           - name: UHD Bluray + WEB (GER)
 

--- a/sonarr/templates/german-uhd-remux-web-v4.yml
+++ b/sonarr/templates/german-uhd-remux-web-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Remux + WEB (GER)                                         #
-# Updated: 2025-01-20                                                                             #
+# Updated: 2025-01-26                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -29,7 +29,6 @@ sonarr:
 #          - 82d40da2bc6923f41e14394075dd4b03 # No-RlsGroup
 #          - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
 #          - 06d66ab109d4d2eddb2794d21526d140 # Retags
-#          - 1b3994c551cbb92a2c781af061f4ab44 # Scene
         assign_scores_to:
           - name: UHD Remux + WEB (GER)
 


### PR DESCRIPTION
Remove international Scene CF from optionals to avoid wrong scoring due to different german release naming.