### PR TITLE
Fix: reset unmatched scores should be true in the german guide templates

### DIFF
--- a/radarr/includes/quality-profiles/radarr-quality-profile-hd-bluray-web-german.yml
+++ b/radarr/includes/quality-profiles/radarr-quality-profile-hd-bluray-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: HD Bluray + WEB (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true

--- a/radarr/includes/quality-profiles/radarr-quality-profile-uhd-bluray-web-german.yml
+++ b/radarr/includes/quality-profiles/radarr-quality-profile-uhd-bluray-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: UHD Bluray + WEB (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true

--- a/radarr/includes/quality-profiles/radarr-quality-profile-uhd-remux-web-german.yml
+++ b/radarr/includes/quality-profiles/radarr-quality-profile-uhd-remux-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: Remux + WEB 2160p (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true

--- a/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-hd-bluray-web-german.yml
+++ b/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-hd-bluray-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: HD Bluray + WEB (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true

--- a/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-hd-remux-web-german.yml
+++ b/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-hd-remux-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: HD Remux + WEB (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true

--- a/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-uhd-bluray-web-german.yml
+++ b/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-uhd-bluray-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: UHD Bluray + WEB (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true

--- a/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-uhd-remux-web-german.yml
+++ b/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-uhd-remux-web-german.yml
@@ -1,7 +1,7 @@
 quality_profiles:
   - name: UHD Remux + WEB (GER)
     reset_unmatched_scores:
-      enabled: false
+      enabled: true
     score_set: german
     upgrade:
       allowed: true


### PR DESCRIPTION
reset unmatched scores should be true in the german guide as it is in the other guides templates