### PR TITLE
fix: Removed duplicate AV1 custom format from SQP-1 (2160p) include

### DIFF
--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
@@ -62,7 +62,6 @@ custom_formats:
 
       # Optional
       - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
-      - cae4ca30163749b891686f95532519bd # AV1
 
       # Resolution
       - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p


### PR DESCRIPTION
Removed duplicate AV1 custom format from SQP-1 (2160p) include