### PR TITLE
Do not reset score values in radar-custom-formats-hd-bluray-web include

### DIFF
--- a/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-hd-bluray-web.yml
@@ -48,4 +48,3 @@ custom_formats:
       - c2863d2a50c9acad1fb50e53ece60817 # STAN
     assign_scores_to:
       - name: HD Bluray + WEB
-        score: 0


### PR DESCRIPTION
Seems this was actually done in https://github.com/recyclarr/config-templates/pull/42 but https://github.com/recyclarr/config-templates/commit/0ceb30ad9fe64ea8a567cfb69467637fb48aa19a later copied this file from anime-radarr.yml instead of the old hd-bluray-web.yml, so this score reset was re-applied.

Re-fixes https://github.com/recyclarr/config-templates/issues/41