### PR TITLE
fix: Resolve errors resulting from downstream `EVO (no WEBDL)` custom format removal

### DIFF
--- a/radarr/templates/french-hd-bluray-web.yml
+++ b/radarr/templates/french-hd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: FR HD Bluray + WEB                                            #
-# Updated: 2024-12-05                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: The following will be in French but hold basically the same info as the other template    #
 # ----------------------------------------------------------------------------------------------- #
@@ -51,7 +51,6 @@ radarr:
       # Ils sont optionnels et peuvent ne pas fonctionner correctement avec les profiles FR
       - trash_ids:
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/french-hd-remux-web.yml
+++ b/radarr/templates/french-hd-remux-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: FR HD Remux + WEB                                             #
-# Updated: 2024-12-05                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: The following will be in French but hold basically the same info as the other template    #
 # ----------------------------------------------------------------------------------------------- #
@@ -75,7 +75,6 @@ radarr:
       # Ils sont optionnels et peuvent ne pas fonctionner correctement avec les profiles FR
       - trash_ids:
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/french-uhd-bluray-web.yml
+++ b/radarr/templates/french-uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: FR UHD Bluray + WEB                                           #
-# Updated: 2024-12-05                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: The following will be in French but hold basically the same info as the other template    #
 # ----------------------------------------------------------------------------------------------- #
@@ -99,7 +99,6 @@ radarr:
       # Ils sont optionnels et peuvent ne pas fonctionner correctement avec les profiles FR
       - trash_ids:
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/french-uhd-remux-web.yml
+++ b/radarr/templates/french-uhd-remux-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: FR UHD Remux + WEB                                            #
-# Updated: 2024-12-05                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: The following will be in French but hold basically the same info as the other template    #
 # ----------------------------------------------------------------------------------------------- #
@@ -100,7 +100,6 @@ radarr:
       # Ils sont optionnels et peuvent ne pas fonctionner correctement avec les profiles FR
       - trash_ids:
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB (GER)                                         #
-# Updated: 2025-01-18                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -26,7 +26,6 @@ radarr:
 ### Optional
       - trash_ids:
 #          - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-#          - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
 #          - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
 #          - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
 #          - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB (GER)                                        #
-# Updated: 2025-01-18                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -75,7 +75,6 @@ radarr:
 ### Optional
       - trash_ids:
 #          - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-#          - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
 #          - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
 #          - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
 #          - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Remux + WEB (GER)                                         #
-# Updated: 2025-01-18                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -61,7 +61,6 @@ radarr:
 ### Optional
       - trash_ids:
 #          - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-#          - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
 #          - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
 #          - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
 #          - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: HD Bluray + WEB                                               #
-# Updated: 2025-01-26                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -38,7 +38,6 @@ radarr:
       - trash_ids:
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Remux + WEB 1080p                                             #
-# Updated: 2025-01-26                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -60,7 +60,6 @@ radarr:
       - trash_ids:
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Remux + WEB 2160p                                             #
-# Updated: 2025-01-26                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -60,7 +60,6 @@ radarr:
       - trash_ids:
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/sqp/sqp-1-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-1080p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (1080p)                                                 #
-# Updated: 2025-01-26                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -41,7 +41,6 @@ radarr:
       # Optional - uncomment any of the following if you want them added to your profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (2160p)                                                 #
-# Updated: 2025-01-26                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -70,7 +70,6 @@ radarr:
           # the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/sqp/sqp-1-web-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-web-1080p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 WEB (1080p)                                             #
-# Updated: 2025-01-26                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -41,7 +41,6 @@ radarr:
       # Optional - uncomment any of the following if you want them added to your profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-2                                                         #
-# Updated: 2025-01-26                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -67,7 +67,6 @@ radarr:
           # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-3                                                         #
-# Updated: 2025-01-26                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -67,7 +67,6 @@ radarr:
           # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-4                                                         #
-# Updated: 2025-01-26                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -67,7 +67,6 @@ radarr:
           # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-5                                                         #
-# Updated: 2025-01-26                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -67,7 +67,6 @@ radarr:
           # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB                                              #
-# Updated: 2025-01-26                                                                             #
+# Updated: 2025-05-04                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -59,7 +59,6 @@ radarr:
       - trash_ids:
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
           # - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
           # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags


### PR DESCRIPTION
- Removed `EVO (no WEBDL)` custom format from all templates