### PR TITLE
fix: update templates and includes to reflect new HDR CF changes

### DIFF
--- a/radarr/includes/custom-formats/radarr-custom-formats-remux-web-2160p.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-remux-web-2160p.yml
@@ -1,17 +1,7 @@
 custom_formats:
   - trash_ids:
-      # All HDR Formats
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
 
       # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web.yml
@@ -1,17 +1,7 @@
 custom_formats:
   - trash_ids:
-      # All HDR Formats
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
 
       # HQ Release Groups
       - 4d74ac4c4db0b64bff6ce0cffef99bf0 # UHD Bluray Tier 01

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
@@ -16,18 +16,8 @@ custom_formats:
       - 240770601cc226190c367ef59aba7463 # AAC
       - c2998bd0d90ed5621d8df281e839436e # DD
 
-      # All HDR Formats + DV (WEBDL)
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR + DV (WEBDL)
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
       - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
 
       # HQ Release Groups

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-2.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-2.yml
@@ -16,18 +16,8 @@ custom_formats:
       - 240770601cc226190c367ef59aba7463 # AAC
       - c2998bd0d90ed5621d8df281e839436e # DD
 
-      # HDR Formats
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
 
       # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-3.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-3.yml
@@ -16,18 +16,8 @@ custom_formats:
       - 240770601cc226190c367ef59aba7463 # AAC
       - c2998bd0d90ed5621d8df281e839436e # DD
 
-      # HDR Formats
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
 
       # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-4.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-4.yml
@@ -16,18 +16,8 @@ custom_formats:
       - 240770601cc226190c367ef59aba7463 # AAC
       - c2998bd0d90ed5621d8df281e839436e # DD
 
-      # HDR Formats
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
 
       # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01

--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-5.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-5.yml
@@ -16,18 +16,8 @@ custom_formats:
       - 240770601cc226190c367ef59aba7463 # AAC
       - c2998bd0d90ed5621d8df281e839436e # DD
 
-      # HDR Formats
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
 
       # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Remux + WEB 2160p                                             #
-# Updated: 2025-05-04                                                                             #
+# Updated: 2025-08-28                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -82,9 +82,11 @@ radarr:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
 
-          # HDR10+ Boost - Uncomment the next two lines if any of your devices DO support HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
-          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+          # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
+          # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases
+          # Uncomment both lines if you want to prefer both (DV HDR10+)
+          # - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
+          # - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
         assign_scores_to:
           - name: Remux + WEB 2160p
 

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-1 (2160p)                                                 #
-# Updated: 2025-05-04                                                                             #
+# Updated: 2025-08-28                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -62,9 +62,11 @@ radarr:
 
       # Optional
       - trash_ids:
-          # Uncomment the next two lines if you have a setup that supports HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
-          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+          # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
+          # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases
+          # Uncomment both lines if you want to prefer both (DV HDR10+)
+          # - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
+          # - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
 
           # Uncomment any of the following optional custom formats if you want them to be added to
           # the quality profile

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-2                                                         #
-# Updated: 2025-05-04                                                                             #
+# Updated: 2025-08-28                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -57,9 +57,11 @@ radarr:
 
       # Optional
       - trash_ids:
-          # Uncomment the next two lines if you have a setup that supports HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
-          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+          # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
+          # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases
+          # Uncomment both lines if you want to prefer both (DV HDR10+)
+          # - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
+          # - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
 
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-3                                                         #
-# Updated: 2025-05-04                                                                             #
+# Updated: 2025-08-28                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -57,9 +57,11 @@ radarr:
 
       # Optional
       - trash_ids:
-          # Uncomment the next two lines if you have a setup that supports HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
-          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+          # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
+          # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases
+          # Uncomment both lines if you want to prefer both (DV HDR10+)
+          # - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
+          # - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
 
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-4                                                         #
-# Updated: 2025-05-04                                                                             #
+# Updated: 2025-08-28                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -57,9 +57,11 @@ radarr:
 
       # Optional
       - trash_ids:
-          # Uncomment the next two lines if you have a setup that supports HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
-          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+          # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
+          # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases
+          # Uncomment both lines if you want to prefer both (DV HDR10+)
+          # - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
+          # - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
 
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-5                                                         #
-# Updated: 2025-05-04                                                                             #
+# Updated: 2025-08-28                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -57,9 +57,11 @@ radarr:
 
       # Optional
       - trash_ids:
-          # Uncomment the next two lines if you have a setup that supports HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10+ Boost
-          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+          # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
+          # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases
+          # Uncomment both lines if you want to prefer both (DV HDR10+)
+          # - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
+          # - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
 
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB                                              #
-# Updated: 2025-05-04                                                                             #
+# Updated: 2025-08-28                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -81,9 +81,11 @@ radarr:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
 
-          # HDR10+ Boost - Uncomment the next two lines if any of your devices DO support HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
-          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+          # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
+          # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases
+          # Uncomment both lines if you want to prefer both (DV HDR10+)
+          # - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
+          # - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
         assign_scores_to:
           - name: UHD Bluray + WEB
 

--- a/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-2160p.yml
+++ b/sonarr/includes/custom-formats/sonarr-v4-custom-formats-web-2160p.yml
@@ -1,17 +1,7 @@
 custom_formats:
   - trash_ids:
-      # HDR Formats
-      - 2b239ed870daba8126a53bd5dc8dc1c8 # DV HDR10Plus
-      - 7878c33f1963fefb3d6c8657d46c2f0a # DV HDR10
-      - 1f733af03141f068a540eec352589a89 # DV HLG
-      - 27954b0a80aab882522a88a4d9eae1cd # DV SDR
-      - 6d0d8de7b57e35518ac0308b0ddf404e # DV
-      - bb019e1cd00f304f80971c965de064dc # HDR (undefined)
-      - 3e2c4e748b64a1a1118e0ea3f4cf6875 # HDR
-      - 3497799d29a085e2ac2df9d468413c94 # HDR10
-      - a3d82cbef5039f8d295478d28a887159 # HDR10+
-      - 17e889ce13117940092308f48b48b45b # HLG
-      - 2a7e3be05d3861d6df7171ec74cad727 # PQ
+      # Unified HDR
+      - 505d871304820ba7106b693be6fe4a9e # HDR
 
       # Unwanted
       - 85c61753df5da1fb2aab6f2a47426b09 # BR-DISK

--- a/sonarr/templates/web-2160p-v4.yml
+++ b/sonarr/templates/web-2160p-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: WEB-2160p (V4)                                                #
-# Updated: 2024-10-02                                                                             #
+# Updated: 2025-08-28                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -29,9 +29,11 @@ sonarr:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
 
-          # HDR10+ Boost - Uncomment the next two lines if any of your devices DO support HDR10+
-          # - 0dad0a507451acddd754fe6dc3a7f5e7 # HDR10+ Boost
-          # - 385e9e8581d33133c3961bdcdeffb7b4 # DV HDR10+ Boost
+          # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
+          # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases
+          # Uncomment both lines if you want to prefer both (DV HDR10+)
+          # - 0c4b99df9206d2cfac3c05ab897dd62a # HDR10+ Boost
+          # - 7c3a61a9c6cb04f52f1544be6d44a026 # DV Boost
         assign_scores_to:
           - name: WEB-2160p
 


### PR DESCRIPTION
Update recyclarr templates and includes to reflect the upcoming TRaSH Guides HDR refactor (https://github.com/TRaSH-Guides/Guides/pull/2455)

I left the French and German templates alone at this time as I'm unfamiliar with them.