### PR TITLE
fix: update german templates for the HDR refactor

### DIFF
--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-german.yml
@@ -19,18 +19,8 @@ custom_formats:
       - 263943bc5d99550c68aad0c4278ba1c7 # German LQ
       - 03c430f326f10a27a9739b8bc83c30e4 # German Microsized
 
-      # All HDR Formats
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
 
       # HQ Release Groups
       - 4d74ac4c4db0b64bff6ce0cffef99bf0 # UHD Bluray Tier 01

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-german.yml
@@ -18,18 +18,8 @@ custom_formats:
       - 263943bc5d99550c68aad0c4278ba1c7 # German LQ
       - 03c430f326f10a27a9739b8bc83c30e4 # German Microsized
 
-      # All HDR Formats
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
 
       # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB (GER)                                        #
-# Updated: 2025-01-18                                                                             #
+# Updated: 2025-08-25                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -88,9 +88,11 @@ radarr:
 # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
 
-# HDR10+ Boost - Uncomment the next two lines if any of your devices DO support HDR10+
-#          - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
-#          - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+# HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
+# DV Boost - Uncomment the DV Boost line if you want to prefer DV releases
+# Uncomment both lines if you want to prefer both (DV HDR10+)
+#           - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
+#           - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
         assign_scores_to:
           - name: UHD Bluray + WEB (GER)
 

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Remux + WEB (GER)                                         #
-# Updated: 2025-01-18                                                                             #
+# Updated: 2025-08-25                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -74,9 +74,11 @@ radarr:
 # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
 
-# HDR10+ Boost - Uncomment the next two lines if any of your devices DO support HDR10+
-#          - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
-#          - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+# HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
+# DV Boost - Uncomment the DV Boost line if you want to prefer DV releases
+# Uncomment both lines if you want to prefer both (DV HDR10+)
+#           - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
+#           - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
         assign_scores_to:
           - name: Remux + WEB 2160p (GER)
 

--- a/sonarr/includes/custom-formats/sonarr-v4-custom-formats-uhd-bluray-web-german.yml
+++ b/sonarr/includes/custom-formats/sonarr-v4-custom-formats-uhd-bluray-web-german.yml
@@ -19,18 +19,8 @@ custom_formats:
       - a6a6c33d057406aaad978a6902823c35 # German LQ
       - 237eda4ef550a97da2c9d87b437e500b # German Microsized
 
-      # All HDR Formats
-      - 2b239ed870daba8126a53bd5dc8dc1c8 # DV HDR10Plus
-      - 7878c33f1963fefb3d6c8657d46c2f0a # DV HDR10
-      - 1f733af03141f068a540eec352589a89 # DV HLG
-      - 27954b0a80aab882522a88a4d9eae1cd # DV SDR
-      - 6d0d8de7b57e35518ac0308b0ddf404e # DV
-      - bb019e1cd00f304f80971c965de064dc # HDR (undefined)
-      - 3e2c4e748b64a1a1118e0ea3f4cf6875 # HDR
-      - 3497799d29a085e2ac2df9d468413c94 # HDR10
-      - a3d82cbef5039f8d295478d28a887159 # HDR10+
-      - 17e889ce13117940092308f48b48b45b # HLG
-      - 2a7e3be05d3861d6df7171ec74cad727 # PQ
+        # Unified HDR
+      - 505d871304820ba7106b693be6fe4a9e # HDR
 
       # HQ Source Groups
       - e6258996055b9fbab7e9cb2f75819294 # WEB Tier 01

--- a/sonarr/includes/custom-formats/sonarr-v4-custom-formats-uhd-remux-web-german.yml
+++ b/sonarr/includes/custom-formats/sonarr-v4-custom-formats-uhd-remux-web-german.yml
@@ -18,18 +18,8 @@ custom_formats:
       - a6a6c33d057406aaad978a6902823c35 # German LQ
       - 237eda4ef550a97da2c9d87b437e500b # German Microsized
 
-      # All HDR Formats
-      - 2b239ed870daba8126a53bd5dc8dc1c8 # DV HDR10Plus
-      - 7878c33f1963fefb3d6c8657d46c2f0a # DV HDR10
-      - 1f733af03141f068a540eec352589a89 # DV HLG
-      - 27954b0a80aab882522a88a4d9eae1cd # DV SDR
-      - 6d0d8de7b57e35518ac0308b0ddf404e # DV
-      - bb019e1cd00f304f80971c965de064dc # HDR (undefined)
-      - 3e2c4e748b64a1a1118e0ea3f4cf6875 # HDR
-      - 3497799d29a085e2ac2df9d468413c94 # HDR10
-      - a3d82cbef5039f8d295478d28a887159 # HDR10+
-      - 17e889ce13117940092308f48b48b45b # HLG
-      - 2a7e3be05d3861d6df7171ec74cad727 # PQ
+      # Unified HDR
+      - 505d871304820ba7106b693be6fe4a9e # HDR
 
       # HQ Source Groups
       - e6258996055b9fbab7e9cb2f75819294 # WEB Tier 01

--- a/sonarr/templates/german-uhd-bluray-web-v4.yml
+++ b/sonarr/templates/german-uhd-bluray-web-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB (GER)                                        #
-# Updated: 2025-01-20                                                                             #
+# Updated: 2025-08-25                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -52,9 +52,11 @@ sonarr:
 # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
 
-# HDR10+ Boost - Uncomment the next two lines if any of your devices DO support HDR10+
-#          - 0dad0a507451acddd754fe6dc3a7f5e7 # HDR10Plus Boost
-#          - 385e9e8581d33133c3961bdcdeffb7b4 # DV HDR10+ Boost
+# HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
+# DV Boost - Uncomment the DV Boost line if you want to prefer DV releases
+# Uncomment both lines if you want to prefer both (DV HDR10+)
+#         - 0c4b99df9206d2cfac3c05ab897dd62a # HDR10+ Boost
+#         - 7c3a61a9c6cb04f52f1544be6d44a026 # DV Boost
         assign_scores_to:
           - name: UHD Bluray + WEB (GER)
 

--- a/sonarr/templates/german-uhd-remux-web-v4.yml
+++ b/sonarr/templates/german-uhd-remux-web-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Remux + WEB (GER)                                         #
-# Updated: 2025-01-20                                                                             #
+# # Updated: 2025-08-25                                                                           #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -38,9 +38,11 @@ sonarr:
 # Comment out the next line if you and all of your users' setups are fully DV compatible
           - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
 
-# HDR10+ Boost - Uncomment the next two lines if any of your devices DO support HDR10+
-#          - 0dad0a507451acddd754fe6dc3a7f5e7 # HDR10Plus Boost
-#          - 385e9e8581d33133c3961bdcdeffb7b4 # DV HDR10+ Boost
+# HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
+# DV Boost - Uncomment the DV Boost line if you want to prefer DV releases
+# Uncomment both lines if you want to prefer both (DV HDR10+)
+#         - 0c4b99df9206d2cfac3c05ab897dd62a # HDR10+ Boost
+#         - 7c3a61a9c6cb04f52f1544be6d44a026 # DV Boost
         assign_scores_to:
           - name: UHD Remux + WEB (GER)
 


### PR DESCRIPTION
Update German recyclarr templates and includes to reflect the upcoming TRaSH Guides HDR refactor (https://github.com/TRaSH-Guides/Guides/pull/2455)