### PR TITLE
fix: update French templates to reflect the upcoming HDR CF changes

### DIFF
--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-french-multi-vf.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-french-multi-vf.yml
@@ -6,18 +6,8 @@ custom_formats:
       - 0542a48746585dc4444bbbb8a6bdf6ea # Language: Original + French
       - 4b900e171accbfb172729b63323ea8ca # MULTi
 
-      # All HDR Formats
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
 
       # FR HQ Source Groups
       - 64f8f12bbf7472a6ccf838bfd6b5e3e8 # FR UHD Bluray Tier 01

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-french-multi-vo.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-french-multi-vo.yml
@@ -6,18 +6,8 @@ custom_formats:
       - 0542a48746585dc4444bbbb8a6bdf6ea # Language: Original + French
       - 4b900e171accbfb172729b63323ea8ca # MULTi
 
-      # All HDR Formats
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
 
       # FR HQ Source Groups
       - 64f8f12bbf7472a6ccf838bfd6b5e3e8 # FR UHD Bluray Tier 01

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-french-vostfr.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-bluray-web-french-vostfr.yml
@@ -7,18 +7,8 @@ custom_formats:
       - 4b900e171accbfb172729b63323ea8ca # MULTi
       - 9172b2f683f6223e3a1846427b417a3d # VOSTFR
 
-      # All HDR Formats
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
 
       # HQ Release Groups
       - 4d74ac4c4db0b64bff6ce0cffef99bf0 # UHD Bluray Tier 01

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-french-multi-vf.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-french-multi-vf.yml
@@ -6,6 +6,9 @@ custom_formats:
       - 0542a48746585dc4444bbbb8a6bdf6ea # Language: Original + French
       - 4b900e171accbfb172729b63323ea8ca # MULTi
 
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
+
       # FR HQ Source Groups
       - 5583260016e0b9f683f53af41fb42e4a # FR Remux Tier 01
       - 9019d81307e68cd4a7eb06a567e833b8 # FR Remux Tier 02

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-french-multi-vo.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-french-multi-vo.yml
@@ -6,18 +6,8 @@ custom_formats:
       - 0542a48746585dc4444bbbb8a6bdf6ea # Language: Original + French
       - 4b900e171accbfb172729b63323ea8ca # MULTi
 
-      # All HDR Formats
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
 
       # FR HQ Source Groups
       - 5583260016e0b9f683f53af41fb42e4a # FR Remux Tier 01

--- a/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-french-vostfr.yml
+++ b/radarr/includes/custom-formats/radarr-custom-formats-uhd-remux-web-french-vostfr.yml
@@ -7,18 +7,8 @@ custom_formats:
       - 4b900e171accbfb172729b63323ea8ca # MULTi
       - 9172b2f683f6223e3a1846427b417a3d # VOSTFR
 
-      # All HDR Formats
-      - c53085ddbd027d9624b320627748612f # DV HDR10Plus
-      - e23edd2482476e595fb990b12e7c609c # DV HDR10
-      - 58d6a88f13e2db7f5059c41047876f00 # DV
-      - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-      - a3e19f8f627608af0211acd02bf89735 # DV SDR
-      - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-      - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-      - e61e28db95d22bedcadf030b8f156d96 # HDR
-      - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-      - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-      - 9364dd386c9b4a1100dde8264690add7 # HLG
+      # Unified HDR
+      - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
 
       # HQ Release Groups
       - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01

--- a/radarr/templates/french-uhd-bluray-web.yml
+++ b/radarr/templates/french-uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: FR UHD Bluray + WEB                                           #
-# Updated: 2025-05-04                                                                             #
+# Updated: 2025-08-27                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: The following will be in French but hold basically the same info as the other template    #
 # ----------------------------------------------------------------------------------------------- #
@@ -58,10 +58,11 @@ radarr:
           # Commentez la ligne suivante si vous et tous vos utilisateurs
           # avez des configurations entièrement compatibles DV
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
-          # HDR10+ Boost
-          # Décommentez les deux lignes suivantes si l'un de vos appareils prend en charge le HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
-          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+          # DV Boost - Décommentez la ligne si vous voulez préférer le DV
+          # HDR10+ Boost - Décommentez la ligne si vous voulez préférer le HDR10+
+          # Décommentez les deux lignes si vous voulez préférer les deux
+          # - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
+          # - caa37d0df9c348912df1fb1d88f9273a # HDR10Plus Boost
         assign_scores_to:
           # - name: FR-VOSTFR-UHD
           # - name: FR-MULTi-VF-UHD

--- a/radarr/templates/french-uhd-remux-web.yml
+++ b/radarr/templates/french-uhd-remux-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: FR UHD Remux + WEB                                            #
-# Updated: 2025-05-04                                                                             #
+# Updated: 2025-08-27                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: The following will be in French but hold basically the same info as the other template    #
 # ----------------------------------------------------------------------------------------------- #
@@ -58,10 +58,11 @@ radarr:
           # Commentez la ligne suivante si vous et tous vos utilisateurs
           # avez des configurations entièrement compatibles DV
           - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
-          # HDR10+ Boost
-          # Décommentez les deux lignes suivantes si l'un de vos appareils prend en charge le HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
-          # - 55a5b50cb416dea5a50c4955896217ab # DV HDR10+ Boost
+          # DV Boost - Décommentez la ligne si vous voulez préférer le DV
+          # HDR10+ Boost - Décommentez la ligne si vous voulez préférer le HDR10+
+          # Décommentez les deux lignes si vous voulez préférer les deux
+          # - b337d6812e06c200ec9a2d3cfa9d20a7 # DV Boost
+          # - caa37d0df9c348912df1fb1d88f9273a # HDR10Plus Boost
         assign_scores_to:
           # - name: FR-REMUX-VOSTFR-UHD
           # - name: FR-REMUX-MULTi-VF-UHD

--- a/sonarr/includes/custom-formats/sonarr-v4-custom-formats-bluray-web-2160p-french-multi-vf.yml
+++ b/sonarr/includes/custom-formats/sonarr-v4-custom-formats-bluray-web-2160p-french-multi-vf.yml
@@ -6,18 +6,8 @@ custom_formats:
       - 10e77b96ae4770a7de645a91a53ce29a # Language: Original + French
       - 7ba05c6e0e14e793538174c679126996 # MULTi
 
-      # HDR Formats
-      - 2b239ed870daba8126a53bd5dc8dc1c8 # DV HDR10Plus
-      - 7878c33f1963fefb3d6c8657d46c2f0a # DV HDR10
-      - 1f733af03141f068a540eec352589a89 # DV HLG
-      - 27954b0a80aab882522a88a4d9eae1cd # DV SDR
-      - 6d0d8de7b57e35518ac0308b0ddf404e # DV
-      - bb019e1cd00f304f80971c965de064dc # HDR (undefined)
-      - 3e2c4e748b64a1a1118e0ea3f4cf6875 # HDR
-      - 3497799d29a085e2ac2df9d468413c94 # HDR10
-      - a3d82cbef5039f8d295478d28a887159 # HDR10+
-      - 17e889ce13117940092308f48b48b45b # HLG
-      - 2a7e3be05d3861d6df7171ec74cad727 # PQ
+      # Unified HDR
+      - 505d871304820ba7106b693be6fe4a9e # HDR
 
       # Unwanted
       - 85c61753df5da1fb2aab6f2a47426b09 # BR-DISK

--- a/sonarr/includes/custom-formats/sonarr-v4-custom-formats-bluray-web-2160p-french-multi-vo.yml
+++ b/sonarr/includes/custom-formats/sonarr-v4-custom-formats-bluray-web-2160p-french-multi-vo.yml
@@ -6,18 +6,8 @@ custom_formats:
       - 10e77b96ae4770a7de645a91a53ce29a # Language: Original + French
       - 7ba05c6e0e14e793538174c679126996 # MULTi
 
-      # HDR Formats
-      - 2b239ed870daba8126a53bd5dc8dc1c8 # DV HDR10Plus
-      - 7878c33f1963fefb3d6c8657d46c2f0a # DV HDR10
-      - 1f733af03141f068a540eec352589a89 # DV HLG
-      - 27954b0a80aab882522a88a4d9eae1cd # DV SDR
-      - 6d0d8de7b57e35518ac0308b0ddf404e # DV
-      - bb019e1cd00f304f80971c965de064dc # HDR (undefined)
-      - 3e2c4e748b64a1a1118e0ea3f4cf6875 # HDR
-      - 3497799d29a085e2ac2df9d468413c94 # HDR10
-      - a3d82cbef5039f8d295478d28a887159 # HDR10+
-      - 17e889ce13117940092308f48b48b45b # HLG
-      - 2a7e3be05d3861d6df7171ec74cad727 # PQ
+      # Unified HDR
+      - 505d871304820ba7106b693be6fe4a9e # HDR
 
       # Unwanted
       - 85c61753df5da1fb2aab6f2a47426b09 # BR-DISK

--- a/sonarr/includes/custom-formats/sonarr-v4-custom-formats-bluray-web-2160p-french-vostfr.yml
+++ b/sonarr/includes/custom-formats/sonarr-v4-custom-formats-bluray-web-2160p-french-vostfr.yml
@@ -6,18 +6,8 @@ custom_formats:
       - 10e77b96ae4770a7de645a91a53ce29a # Language: Original + French
       - 7ba05c6e0e14e793538174c679126996 # MULTi
 
-      # HDR Formats
-      - 2b239ed870daba8126a53bd5dc8dc1c8 # DV HDR10Plus
-      - 7878c33f1963fefb3d6c8657d46c2f0a # DV HDR10
-      - 1f733af03141f068a540eec352589a89 # DV HLG
-      - 27954b0a80aab882522a88a4d9eae1cd # DV SDR
-      - 6d0d8de7b57e35518ac0308b0ddf404e # DV
-      - bb019e1cd00f304f80971c965de064dc # HDR (undefined)
-      - 3e2c4e748b64a1a1118e0ea3f4cf6875 # HDR
-      - 3497799d29a085e2ac2df9d468413c94 # HDR10
-      - a3d82cbef5039f8d295478d28a887159 # HDR10+
-      - 17e889ce13117940092308f48b48b45b # HLG
-      - 2a7e3be05d3861d6df7171ec74cad727 # PQ
+      # Unified HDR
+      - 505d871304820ba7106b693be6fe4a9e # HDR
 
       # Unwanted
       - 85c61753df5da1fb2aab6f2a47426b09 # BR-DISK

--- a/sonarr/templates/french-bluray-web-2160p-v4.yml
+++ b/sonarr/templates/french-bluray-web-2160p-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: FR-BLURAY-WEB-2160p (V4)                                      #
-# Updated: 2024-12-03                                                                             #
+# Updated: 2025-08-27                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: The following will be in French but hold basically the same info as the other template    #
 # ----------------------------------------------------------------------------------------------- #
@@ -37,10 +37,11 @@ sonarr:
           # Commentez la ligne suivante si vous et tous vos utilisateurs
           # avez des configurations entièrement compatibles DV
           - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
-          # HDR10+ Boost
-          # Décommentez les deux lignes suivantes si l'un de vos appareils prend en charge le HDR10+
-          # - 0dad0a507451acddd754fe6dc3a7f5e7 # HDR10+ Boost
-          # - 385e9e8581d33133c3961bdcdeffb7b4 # DV HDR10+ Boost
+          # DV Boost - Décommentez la ligne si vous voulez préférer le DV
+          # HDR10+ Boost - Décommentez la ligne si vous voulez préférer le HDR10+
+          # Décommentez les deux lignes si vous voulez préférer les deux
+          # - 7c3a61a9c6cb04f52f1544be6d44a026 # DV Boost
+          # - 0c4b99df9206d2cfac3c05ab897dd62a # HDR10Plus Boost
         assign_scores_to:
           # - name: FR-VOSTFR-WEB-2160p
           # - name: FR-MULTi-VF-WEB-2160p


### PR DESCRIPTION
Update French recyclarr templates and includes to reflect the upcoming TRaSH Guides HDR refactor (TRaSH-Guides/Guides#2455)

Also fix one of the French template missing HDR format