### PR TITLE
chore: change `DV (WEBDL)` name to `DV w/o HDR (WEBDL)`

### DIFF
--- a/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
+++ b/radarr/includes/custom-formats/sqp/radarr-custom-formats-sqp-1-2160p.yml
@@ -16,9 +16,9 @@ custom_formats:
       - 240770601cc226190c367ef59aba7463 # AAC
       - c2998bd0d90ed5621d8df281e839436e # DD
 
-      # Unified HDR + DV (WEBDL)
+      # Unified HDR + DV (w/o HDR fallback)
       - 493b6d1dbec3c3364c59d7607f7e3405 # HDR
-      - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+      - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
 
       # HQ Release Groups
       - 5153ec7413d9dae44e24275589b5e944 # BHDStudio

--- a/radarr/templates/french-uhd-bluray-web.yml
+++ b/radarr/templates/french-uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: FR UHD Bluray + WEB                                           #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: The following will be in French but hold basically the same info as the other template    #
 # ----------------------------------------------------------------------------------------------- #
@@ -57,7 +57,7 @@ radarr:
       - trash_ids:
           # Commentez la ligne suivante si vous et tous vos utilisateurs
           # avez des configurations entièrement compatibles DV
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
           # DV Boost - Décommentez la ligne si vous voulez préférer le DV
           # HDR10+ Boost - Décommentez la ligne si vous voulez préférer le HDR10+
           # Décommentez les deux lignes si vous voulez préférer les deux

--- a/radarr/templates/french-uhd-remux-web.yml
+++ b/radarr/templates/french-uhd-remux-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: FR UHD Remux + WEB                                            #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: The following will be in French but hold basically the same info as the other template    #
 # ----------------------------------------------------------------------------------------------- #
@@ -57,7 +57,7 @@ radarr:
       - trash_ids:
           # Commentez la ligne suivante si vous et tous vos utilisateurs
           # avez des configurations entièrement compatibles DV
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
           # DV Boost - Décommentez la ligne si vous voulez préférer le DV
           # HDR10+ Boost - Décommentez la ligne si vous voulez préférer le HDR10+
           # Décommentez les deux lignes si vous voulez préférer les deux

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB (GER)                                        #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -85,7 +85,7 @@ radarr:
 ### HDR / DV
       - trash_ids:
 # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
 
 # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
 # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Remux + WEB (GER)                                         #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -71,7 +71,7 @@ radarr:
 ### HDR / DV
       - trash_ids:
 # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
 
 # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
 # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: Remux + WEB 2160p                                             #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -80,7 +80,7 @@ radarr:
 
       - trash_ids:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
 
           # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
           # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-2                                                         #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -64,7 +64,7 @@ radarr:
           # - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
 
           # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
 
           # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-3                                                         #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -64,7 +64,7 @@ radarr:
           # - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
 
           # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
 
           # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-4                                                         #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -64,7 +64,7 @@ radarr:
           # - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
 
           # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
 
           # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: SQP-5                                                         #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -64,7 +64,7 @@ radarr:
           # - caa37d0df9c348912df1fb1d88f9273a # HDR10+ Boost
 
           # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
 
           # Uncomment any of the following if you want them to be added to the quality profile
           # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB                                              #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -79,7 +79,7 @@ radarr:
 
       - trash_ids:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (w/o HDR fallback)
 
           # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
           # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases

--- a/sonarr/templates/french-bluray-web-2160p-v4.yml
+++ b/sonarr/templates/french-bluray-web-2160p-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: FR-BLURAY-WEB-2160p (V4)                                      #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: The following will be in French but hold basically the same info as the other template    #
 # ----------------------------------------------------------------------------------------------- #
@@ -36,7 +36,7 @@ sonarr:
       - trash_ids:
           # Commentez la ligne suivante si vous et tous vos utilisateurs
           # avez des configurations entièrement compatibles DV
-          - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
+          - 9b27ab6498ec0f31a3353992e19434ca # DV (w/o HDR fallback)
           # DV Boost - Décommentez la ligne si vous voulez préférer le DV
           # HDR10+ Boost - Décommentez la ligne si vous voulez préférer le HDR10+
           # Décommentez les deux lignes si vous voulez préférer les deux

--- a/sonarr/templates/german-uhd-bluray-web-v4.yml
+++ b/sonarr/templates/german-uhd-bluray-web-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Bluray + WEB (GER)                                        #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -50,7 +50,7 @@ sonarr:
 ### HDR / DV
       - trash_ids:
 # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
+          - 9b27ab6498ec0f31a3353992e19434ca # DV (w/o HDR fallback)
 
 # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
 # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases

--- a/sonarr/templates/german-uhd-remux-web-v4.yml
+++ b/sonarr/templates/german-uhd-remux-web-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: UHD Remux + WEB (GER)                                         #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -36,7 +36,7 @@ sonarr:
 ### HDR / DV
       - trash_ids:
 # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
+          - 9b27ab6498ec0f31a3353992e19434ca # DV (w/o HDR fallback)
 
 # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
 # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases

--- a/sonarr/templates/web-2160p-v4.yml
+++ b/sonarr/templates/web-2160p-v4.yml
@@ -1,6 +1,6 @@
 ###################################################################################################
 # Recyclarr Configuration Template: WEB-2160p (V4)                                                #
-# Updated: 2025-08-28                                                                             #
+# Updated: 2025-09-07                                                                             #
 # Documentation: https://recyclarr.dev                                                            #
 # Note: If you are using multiple profiles in a single instance, please read the following        #
 # documentation about file merging:                                                               #
@@ -27,7 +27,7 @@ sonarr:
       # HDR Formats
       - trash_ids:
           # Comment out the next line if you and all of your users' setups are fully DV compatible
-          - 9b27ab6498ec0f31a3353992e19434ca # DV (WEBDL)
+          - 9b27ab6498ec0f31a3353992e19434ca # DV (w/o HDR fallback)
 
           # HDR10+ Boost - Uncomment the HDR10+ Boost line if you want to prefer HDR10+ releases
           # DV Boost - Uncomment the DV Boost line if you want to prefer DV releases


### PR DESCRIPTION
- Replaced all instances of `DV (WEBDL)` with `DV w/o HDR (WEBDL)`
- This applies consistency with an upcoming Guides change