### PR TITLE
Remove Blueray-2160p Remux from WEB-2160p-alt

### DIFF
--- a/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-web-2160p-alternative.yml
+++ b/sonarr/includes/quality-profiles/sonarr-v4-quality-profile-web-2160p-alternative.yml
@@ -17,7 +17,6 @@ quality_profiles:
         qualities:
           - WEBDL-1080p
           - WEBRip-1080p
-      - name: Bluray-2160p Remux
       - name: Bluray-2160p
       - name: Bluray-1080p
       - name: HDTV-1080p


### PR DESCRIPTION
Blueray-2160p Remux was included in the template sonarr-v4-quality-profile-web-2160p-alternative.yml incorrectly

See #141