### PR TITLE
Expand CF group output with select blocks and skip section

### DIFF
--- a/ci/CheckInvalidTrashIds.ps1
+++ b/ci/CheckInvalidTrashIds.ps1
@@ -53,8 +53,13 @@ function CheckTrashIdCorrect($yamlDir, $shouldBeIn, $shouldNotBeIn) {
     }
 }
 
-$radarrTrashIds = GetTrashIds "$PathToTrashRepo/docs/json/radarr/cf"
-$sonarrTrashIds = GetTrashIds "$PathToTrashRepo/docs/json/sonarr/cf"
+$radarrTrashIds = GetTrashIds `
+    "$PathToTrashRepo/docs/json/radarr/cf", `
+    "$PathToTrashRepo/docs/json/radarr/cf-groups"
+
+$sonarrTrashIds = GetTrashIds `
+    "$PathToTrashRepo/docs/json/sonarr/cf", `
+    "$PathToTrashRepo/docs/json/sonarr/cf-groups"
 
 CheckTrashIdCorrect "$PathToConfigRepo/sonarr" $sonarrTrashIds $radarrTrashIds
 CheckTrashIdCorrect "$PathToConfigRepo/radarr" $radarrTrashIds $sonarrTrashIds

--- a/radarr/templates/anime-remux-1080p.yml
+++ b/radarr/templates/anime-remux-1080p.yml
@@ -16,8 +16,29 @@ radarr:
 
     custom_format_groups:
       add:
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-hd-bluray-web.yml
+++ b/radarr/templates/french-hd-bluray-web.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
+          select:
+            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -68,5 +72,4 @@ radarr:
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
       skip:
-        # - f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-hd-bluray-web.yml
+++ b/radarr/templates/french-hd-bluray-web.yml
@@ -16,11 +16,57 @@ radarr:
 
     custom_format_groups:
       add:
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
+        #   select:
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-hd-remux-1080p.yml
+++ b/radarr/templates/french-hd-remux-1080p.yml
@@ -16,12 +16,62 @@ radarr:
 
     custom_format_groups:
       add:
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
+        #   select:
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-hd-remux-1080p.yml
+++ b/radarr/templates/french-hd-remux-1080p.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
+          select:
+            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -73,5 +77,4 @@ radarr:
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
-        # - f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-uhd-bluray-web.yml
+++ b/radarr/templates/french-uhd-bluray-web.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -77,5 +81,4 @@ radarr:
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-uhd-bluray-web.yml
+++ b/radarr/templates/french-uhd-bluray-web.yml
@@ -19,12 +19,63 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
+        #   select:
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-uhd-remux-2160p.yml
+++ b/radarr/templates/french-uhd-remux-2160p.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -77,5 +81,4 @@ radarr:
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-uhd-remux-2160p.yml
+++ b/radarr/templates/french-uhd-remux-2160p.yml
@@ -19,12 +19,63 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
+        #   select:
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
+          select:
+            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -68,5 +72,4 @@ radarr:
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
       skip:
-        # - f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -16,11 +16,57 @@ radarr:
 
     custom_format_groups:
       add:
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
+        #   select:
+        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
+        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
+        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
+        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
+        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
+        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
+        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
+        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
+        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/german-hd-remux-web.yml
+++ b/radarr/templates/german-hd-remux-web.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
+          select:
+            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -69,5 +73,4 @@ radarr:
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
-        # - f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/german-hd-remux-web.yml
+++ b/radarr/templates/german-hd-remux-web.yml
@@ -16,11 +16,58 @@ radarr:
 
     custom_format_groups:
       add:
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
+        #   select:
+        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
+        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
+        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
+        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
+        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
+        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
+        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
+        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
+        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/german-remux-web-2160p.yml
+++ b/radarr/templates/german-remux-web-2160p.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -77,5 +81,4 @@ radarr:
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/german-remux-web-2160p.yml
+++ b/radarr/templates/german-remux-web-2160p.yml
@@ -19,12 +19,63 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
+        #   select:
+        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
+        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
+        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
+        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
+        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
+        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
+        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
+        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
+        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/radarr/templates/german-uhd-bluray-web-alternative.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -77,5 +81,4 @@ radarr:
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/radarr/templates/german-uhd-bluray-web-alternative.yml
@@ -19,12 +19,63 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
+        #   select:
+        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
+        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
+        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
+        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
+        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
+        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
+        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
+        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
+        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -77,5 +81,4 @@ radarr:
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -19,12 +19,63 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
+        #   select:
+        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
+        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
+        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
+        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
+        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
+        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
+        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
+        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
+        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -16,10 +16,46 @@ radarr:
 
     custom_format_groups:
       add:
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
+          select:
+            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -57,5 +61,4 @@ radarr:
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
       skip:
-        # - f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/remux-2160p-alternative.yml
+++ b/radarr/templates/remux-2160p-alternative.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -66,5 +70,4 @@ radarr:
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/remux-2160p-alternative.yml
+++ b/radarr/templates/remux-2160p-alternative.yml
@@ -19,11 +19,52 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/remux-2160p-combined.yml
+++ b/radarr/templates/remux-2160p-combined.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -66,5 +70,4 @@ radarr:
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/remux-2160p-combined.yml
+++ b/radarr/templates/remux-2160p-combined.yml
@@ -19,11 +19,52 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
+          select:
+            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -58,5 +62,4 @@ radarr:
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
-        # - f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -16,10 +16,47 @@ radarr:
 
     custom_format_groups:
       add:
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -66,5 +70,4 @@ radarr:
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -19,11 +19,52 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-1-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-1080p.yml
@@ -15,9 +15,44 @@ radarr:
 
     custom_format_groups:
       add:
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -17,10 +17,49 @@ radarr:
       add:
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-1-web-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-web-1080p.yml
@@ -15,9 +15,44 @@ radarr:
 
     custom_format_groups:
       add:
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-1-web-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-web-2160p.yml
@@ -17,10 +17,49 @@ radarr:
       add:
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -15,6 +15,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -63,6 +67,5 @@ radarr:
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - feee39414cb4052dbc55d8752f87e211  # [SQP] Disable if one Radarr
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -18,10 +18,51 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: c4492eebd0c2ddc14c2c91623aa7f95d  # [Optional] Miscellaneous SQP
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: c4492eebd0c2ddc14c2c91623aa7f95d  # [Optional] Miscellaneous SQP
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - feee39414cb4052dbc55d8752f87e211  # [SQP] Disable if one Radarr
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-3-audio.yml
+++ b/radarr/templates/sqp/sqp-3-audio.yml
@@ -15,6 +15,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -62,6 +66,5 @@ radarr:
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
       skip:
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - feee39414cb4052dbc55d8752f87e211  # [SQP] Disable if one Radarr
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-3-audio.yml
+++ b/radarr/templates/sqp/sqp-3-audio.yml
@@ -18,10 +18,50 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: c4492eebd0c2ddc14c2c91623aa7f95d  # [Optional] Miscellaneous SQP
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: c4492eebd0c2ddc14c2c91623aa7f95d  # [Optional] Miscellaneous SQP
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - feee39414cb4052dbc55d8752f87e211  # [SQP] Disable if one Radarr
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -15,6 +15,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -63,6 +67,5 @@ radarr:
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - feee39414cb4052dbc55d8752f87e211  # [SQP] Disable if one Radarr
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -18,10 +18,51 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: c4492eebd0c2ddc14c2c91623aa7f95d  # [Optional] Miscellaneous SQP
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: c4492eebd0c2ddc14c2c91623aa7f95d  # [Optional] Miscellaneous SQP
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - feee39414cb4052dbc55d8752f87e211  # [SQP] Disable if one Radarr
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -15,6 +15,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -63,6 +67,5 @@ radarr:
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - feee39414cb4052dbc55d8752f87e211  # [SQP] Disable if one Radarr
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -18,10 +18,51 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: c4492eebd0c2ddc14c2c91623aa7f95d  # [Optional] Miscellaneous SQP
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: c4492eebd0c2ddc14c2c91623aa7f95d  # [Optional] Miscellaneous SQP
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - feee39414cb4052dbc55d8752f87e211  # [SQP] Disable if one Radarr
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -15,6 +15,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -63,6 +67,5 @@ radarr:
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - feee39414cb4052dbc55d8752f87e211  # [SQP] Disable if one Radarr
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -18,10 +18,51 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: c4492eebd0c2ddc14c2c91623aa7f95d  # [Optional] Miscellaneous SQP
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: c4492eebd0c2ddc14c2c91623aa7f95d  # [Optional] Miscellaneous SQP
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - feee39414cb4052dbc55d8752f87e211  # [SQP] Disable if one Radarr
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -16,6 +16,10 @@ radarr:
 
     custom_format_groups:
       add:
+        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+          select:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -66,5 +70,4 @@ radarr:
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
-        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -19,11 +19,52 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
-        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
         # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
-        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        #   select:
+        #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+        #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+        #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
+        #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
+        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+        #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+        #     - f537cf427b64c38c8e36298f657e4828  # Scene
+        #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
+        #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
+        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
+        #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
+        #     - 390455c22a9cac81a738f6cbad705c3c  # x266
+        # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
+        #   select:
+        #     - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+        #     - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+        #     - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+        #     - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+        #     - 09d9dd29a0fc958f9796e65c2a8864b4  # Open Matte
+        #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
+        #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
+        #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
+        #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+        #     - eecf3a857724171f968a66cb5719e152  # IMAX
+        #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
+        #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
+        #     - fbca986396c5e695ef7b2def3c755d01  # OViD
+        #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+      skip:
+        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
+        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
+        # - ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,91 @@
+# Template Generation Script
+
+`generate-template.py` reads TRaSH Guides quality profile and CF group JSON data to produce
+Recyclarr config templates. Each template gives users a starting point with sensible defaults and
+commented-out options they can toggle.
+
+## CF Group Rendering
+
+The script classifies CF groups into three categories based on their metadata. The rendering
+approach for each category is designed to present user choices clearly in the template YAML, which
+is a separate concern from how Recyclarr processes the groups at runtime.
+
+### Optional groups
+
+Groups where `default` is `false` at the group level. Rendered under `add:`, fully commented out.
+Users uncomment to opt in.
+
+```yaml
+custom_format_groups:
+  add:
+    # - trash_id: abc123  # [Optional] Some Group
+```
+
+If the group contains CFs that are neither `required` nor `default` (i.e. the user must choose which
+to include), a `select:` block is added showing those CFs:
+
+```yaml
+custom_format_groups:
+  add:
+    # - trash_id: abc123  # [Optional] Some Group
+    #   select:
+    #     - def456  # CF One
+    #     - ghi789  # CF Two
+```
+
+### Default groups
+
+Groups where `default` is `true` at the group level and no CFs within the group define `default:
+true`. These are automatically enabled for their target profiles. Rendered under `skip:`, commented
+out. Users uncomment to opt out.
+
+```yaml
+custom_format_groups:
+  skip:
+    # - abc123  # [Required] Some Group
+```
+
+### Default groups with user choices
+
+Groups that are enabled by default but contain mutually exclusive CFs where the user is expected to
+choose one. Detected when a `default: true` group has at least one CF with `default: true` at the CF
+level.
+
+These are rendered under `add:`, **uncommented**, with an explicit `select:` block. CFs marked
+`default: true` are uncommented (active); others are commented out (available as alternatives).
+
+```yaml
+custom_format_groups:
+  add:
+    - trash_id: abc123  # [Required] Golden Rule HD
+      select:
+        - def456  # x265 (HD)
+        # - ghi789  # x265 (no HDR/DV)
+```
+
+This rendering differs from how Recyclarr would handle the group implicitly (it would just apply the
+`default: true` CF without user intervention). The template deliberately surfaces the choice so
+users can see and swap between alternatives. The template is a presentation layer; it does not need
+to mirror Recyclarr's runtime behavior.
+
+Currently only the four Golden Rule groups (HD and UHD, for both Radarr and Sonarr) match this
+pattern.
+
+## Design Decisions
+
+### Template rendering is a presentation concern, not a runtime one (2026-02-28)
+
+Recyclarr automatically applies default CF groups and their `default: true` CFs without any YAML
+configuration. The template generation script does not need to mirror that behavior. Its job is to
+present all meaningful user choices explicitly, even when the defaults would produce the correct
+result without intervention.
+
+This distinction matters for groups like Golden Rule, where two mutually exclusive CFs exist and the
+user is expected to pick one. Recyclarr silently applies the `default: true` CF; a user editing YAML
+by hand would never know the alternative exists. The script renders these as explicit `add:` entries
+with `select:` blocks so the choice is visible. The guide data's `default: true` at the CF level is
+the detection signal for this; no other groups currently use it.
+
+This was a deliberate decision over the simpler approach of putting all `default: true` groups under
+`skip:` uniformly. The trade-off is that the script now has three rendering paths instead of two,
+but the added complexity is justified by the user-facing clarity it provides.

--- a/scripts/generate-template.py
+++ b/scripts/generate-template.py
@@ -26,11 +26,28 @@ SERVICES = ("radarr", "sonarr")
 
 
 @dataclass
+class CustomFormat:
+    trash_id: str
+    name: str
+    required: bool = False
+    default: bool = False
+
+    @property
+    def is_optional(self) -> bool:
+        return not self.required and not self.default
+
+
+@dataclass
 class CFGroup:
     trash_id: str
     name: str
     is_default: bool = False
     target_profiles: dict[str, str] = field(default_factory=dict)
+    custom_formats: list[CustomFormat] = field(default_factory=list)
+
+    @property
+    def optional_cfs(self) -> list[CustomFormat]:
+        return [cf for cf in self.custom_formats if cf.is_optional]
 
 
 @dataclass
@@ -54,6 +71,7 @@ class TemplateSpec:
     quality_def: str
     group_name: str | None
     optional_groups: list[CFGroup]
+    default_groups: list[CFGroup]
 
 
 def load_guides(guides_path: Path) -> dict:
@@ -97,6 +115,15 @@ def load_cf_groups(
             with open(json_file) as f:
                 data = json.load(f)
             default_val = data.get("default", "")
+            cfs = [
+                CustomFormat(
+                    trash_id=cf.get("trash_id", ""),
+                    name=cf.get("name", ""),
+                    required=cf.get("required", False) is True,
+                    default=cf.get("default", False) is True,
+                )
+                for cf in data.get("custom_formats", [])
+            ]
             group = CFGroup(
                 trash_id=data.get("trash_id", ""),
                 name=data.get("name", ""),
@@ -108,6 +135,7 @@ def load_cf_groups(
                     .get("include", {})
                     .items()
                 },
+                custom_formats=cfs,
             )
             groups[group.trash_id] = group
     return groups
@@ -133,13 +161,13 @@ def get_profile_group_name(
     return None
 
 
-def get_optional_cf_groups(
-    cf_groups: dict[str, CFGroup], profile_trash_id: str
+def get_groups_for_profile(
+    cf_groups: dict[str, CFGroup], profile_trash_id: str, *, default: bool
 ) -> list[CFGroup]:
     result = [
         g
         for g in cf_groups.values()
-        if profile_trash_id in g.target_profiles.values() and not g.is_default
+        if profile_trash_id in g.target_profiles.values() and g.is_default == default
     ]
     result.sort(key=lambda g: g.name)
     return result
@@ -206,7 +234,10 @@ def build_template_specs(guides_path: Path) -> list[TemplateSpec]:
         for profile in sorted(profiles.values(), key=lambda p: p.file_stem):
             group_name = get_profile_group_name(profile_groups, profile.trash_id)
             base_id = derive_base_id(profile, group_name)
-            optional = get_optional_cf_groups(cf_groups, profile.trash_id)
+            optional = get_groups_for_profile(
+                cf_groups, profile.trash_id, default=False
+            )
+            default = get_groups_for_profile(cf_groups, profile.trash_id, default=True)
             quality_def = infer_quality_definition(service, profile, group_name)
 
             specs.append(
@@ -219,6 +250,7 @@ def build_template_specs(guides_path: Path) -> list[TemplateSpec]:
                     quality_def=quality_def,
                     group_name=group_name,
                     optional_groups=optional,
+                    default_groups=default,
                 )
             )
 
@@ -262,13 +294,32 @@ def generate_yaml(spec: TemplateSpec) -> str:
     lines.append("        reset_unmatched_scores:")
     lines.append("          enabled: true")
 
-    # Optional CF groups (commented)
-    if spec.optional_groups:
+    # CF groups
+    has_optional = bool(spec.optional_groups)
+    has_default = bool(spec.default_groups)
+    if has_optional or has_default:
         lines.append("")
         lines.append("    custom_format_groups:")
-        lines.append("      add:")
-        for group in spec.optional_groups:
-            lines.append(f"        # - trash_id: {group.trash_id}  # {group.name}")
+
+        if has_optional:
+            simple = [g for g in spec.optional_groups if not g.optional_cfs]
+            expanded = [g for g in spec.optional_groups if g.optional_cfs]
+            simple.sort(key=lambda g: g.name)
+            expanded.sort(key=lambda g: g.name)
+
+            lines.append("      add:")
+            for group in simple:
+                lines.append(f"        # - trash_id: {group.trash_id}  # {group.name}")
+            for group in expanded:
+                lines.append(f"        # - trash_id: {group.trash_id}  # {group.name}")
+                lines.append("        #   select:")
+                for cf in group.optional_cfs:
+                    lines.append(f"        #     - {cf.trash_id}  # {cf.name}")
+
+        if has_default:
+            lines.append("      skip:")
+            for group in spec.default_groups:
+                lines.append(f"        # - {group.trash_id}  # {group.name}")
 
     lines.append("")
     return "\n".join(lines)

--- a/scripts/generate-template.py
+++ b/scripts/generate-template.py
@@ -49,6 +49,10 @@ class CFGroup:
     def optional_cfs(self) -> list[CustomFormat]:
         return [cf for cf in self.custom_formats if cf.is_optional]
 
+    @property
+    def has_cf_defaults(self) -> bool:
+        return any(cf.default for cf in self.custom_formats)
+
 
 @dataclass
 class QualityProfile:
@@ -72,6 +76,7 @@ class TemplateSpec:
     group_name: str | None
     optional_groups: list[CFGroup]
     default_groups: list[CFGroup]
+    choice_groups: list[CFGroup]
 
 
 def load_guides(guides_path: Path) -> dict:
@@ -237,7 +242,11 @@ def build_template_specs(guides_path: Path) -> list[TemplateSpec]:
             optional = get_groups_for_profile(
                 cf_groups, profile.trash_id, default=False
             )
-            default = get_groups_for_profile(cf_groups, profile.trash_id, default=True)
+            all_default = get_groups_for_profile(
+                cf_groups, profile.trash_id, default=True
+            )
+            choice = [g for g in all_default if g.has_cf_defaults]
+            default = [g for g in all_default if not g.has_cf_defaults]
             quality_def = infer_quality_definition(service, profile, group_name)
 
             specs.append(
@@ -251,6 +260,7 @@ def build_template_specs(guides_path: Path) -> list[TemplateSpec]:
                     group_name=group_name,
                     optional_groups=optional,
                     default_groups=default,
+                    choice_groups=choice,
                 )
             )
 
@@ -297,17 +307,30 @@ def generate_yaml(spec: TemplateSpec) -> str:
     # CF groups
     has_optional = bool(spec.optional_groups)
     has_default = bool(spec.default_groups)
-    if has_optional or has_default:
+    has_choice = bool(spec.choice_groups)
+    if has_optional or has_default or has_choice:
         lines.append("")
         lines.append("    custom_format_groups:")
 
-        if has_optional:
+        if has_optional or has_choice:
             simple = [g for g in spec.optional_groups if not g.optional_cfs]
             expanded = [g for g in spec.optional_groups if g.optional_cfs]
             simple.sort(key=lambda g: g.name)
             expanded.sort(key=lambda g: g.name)
 
             lines.append("      add:")
+
+            # Choice groups: uncommented, with select block
+            for group in spec.choice_groups:
+                lines.append(f"        - trash_id: {group.trash_id}  # {group.name}")
+                lines.append("          select:")
+                for cf in group.custom_formats:
+                    if cf.default:
+                        lines.append(f"            - {cf.trash_id}  # {cf.name}")
+                    else:
+                        lines.append(f"            # - {cf.trash_id}  # {cf.name}")
+
+            # Optional groups: commented out
             for group in simple:
                 lines.append(f"        # - trash_id: {group.trash_id}  # {group.name}")
             for group in expanded:

--- a/sonarr/templates/anime-remux-1080p.yml
+++ b/sonarr/templates/anime-remux-1080p.yml
@@ -16,9 +16,32 @@ sonarr:
 
     custom_format_groups:
       add:
-        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        #   select:
+        #     - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+        #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
+        #     - 1bd69272e23c5e6c5b1d6c8a36fce95e  # HFR
+        #     - 7ba05c6e0e14e793538174c679126996  # MULTi
+        #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+        #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
+        #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        #     - 7470a681e6205243983c4410ee4c920f  # VC-1
+        #     - 90501962793d580d011511155c97e4e5  # VP9
+        #     - cddfb4e32db826151d97352b8e37c648  # x264
+        #     - c9eafd50846d299b862ca9bb6ea91950  # x265
+        #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - e6e299075e22ac8f541f722254c8350a  # AUBC
+        #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
+        #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI

--- a/sonarr/templates/french-hd-bluray-web-1080p.yml
+++ b/sonarr/templates/french-hd-bluray-web-1080p.yml
@@ -16,9 +16,35 @@ sonarr:
 
     custom_format_groups:
       add:
-        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
-        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        #   select:
+        #     - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+        #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
+        #     - 1bd69272e23c5e6c5b1d6c8a36fce95e  # HFR
+        #     - 7ba05c6e0e14e793538174c679126996  # MULTi
+        #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+        #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
+        #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        #     - 7470a681e6205243983c4410ee4c920f  # VC-1
+        #     - 90501962793d580d011511155c97e4e5  # VP9
+        #     - cddfb4e32db826151d97352b8e37c648  # x264
+        #     - c9eafd50846d299b862ca9bb6ea91950  # x265
+        #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - e6e299075e22ac8f541f722254c8350a  # AUBC
+        #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
+        #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+      skip:
+        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+        # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/french-hd-bluray-web-1080p.yml
+++ b/sonarr/templates/french-hd-bluray-web-1080p.yml
@@ -16,6 +16,10 @@ sonarr:
 
     custom_format_groups:
       add:
+        - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+          select:
+            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
@@ -46,5 +50,4 @@ sonarr:
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
       skip:
-        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/french-uhd-bluray-web-2160p.yml
+++ b/sonarr/templates/french-uhd-bluray-web-2160p.yml
@@ -19,10 +19,40 @@ sonarr:
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
-        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
-        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        #   select:
+        #     - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+        #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
+        #     - 1bd69272e23c5e6c5b1d6c8a36fce95e  # HFR
+        #     - 7ba05c6e0e14e793538174c679126996  # MULTi
+        #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+        #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
+        #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        #     - 7470a681e6205243983c4410ee4c920f  # VC-1
+        #     - 90501962793d580d011511155c97e4e5  # VP9
+        #     - cddfb4e32db826151d97352b8e37c648  # x264
+        #     - c9eafd50846d299b862ca9bb6ea91950  # x265
+        #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - e6e299075e22ac8f541f722254c8350a  # AUBC
+        #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
+        #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+      skip:
+        # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
+        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+        # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/french-uhd-bluray-web-2160p.yml
+++ b/sonarr/templates/french-uhd-bluray-web-2160p.yml
@@ -16,6 +16,10 @@ sonarr:
 
     custom_format_groups:
       add:
+        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+          select:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
@@ -54,5 +58,4 @@ sonarr:
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
-        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-hd-bluray-web.yml
+++ b/sonarr/templates/german-hd-bluray-web.yml
@@ -16,10 +16,36 @@ sonarr:
 
     custom_format_groups:
       add:
-        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        #   select:
+        #     - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+        #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
+        #     - 1bd69272e23c5e6c5b1d6c8a36fce95e  # HFR
+        #     - 7ba05c6e0e14e793538174c679126996  # MULTi
+        #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+        #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
+        #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        #     - 7470a681e6205243983c4410ee4c920f  # VC-1
+        #     - 90501962793d580d011511155c97e4e5  # VP9
+        #     - cddfb4e32db826151d97352b8e37c648  # x264
+        #     - c9eafd50846d299b862ca9bb6ea91950  # x265
+        #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - e6e299075e22ac8f541f722254c8350a  # AUBC
+        #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
+        #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+      skip:
+        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+        # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-hd-bluray-web.yml
+++ b/sonarr/templates/german-hd-bluray-web.yml
@@ -16,6 +16,10 @@ sonarr:
 
     custom_format_groups:
       add:
+        - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+          select:
+            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
@@ -47,5 +51,4 @@ sonarr:
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
       skip:
-        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-hd-remux-web.yml
+++ b/sonarr/templates/german-hd-remux-web.yml
@@ -16,10 +16,36 @@ sonarr:
 
     custom_format_groups:
       add:
-        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        #   select:
+        #     - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+        #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
+        #     - 1bd69272e23c5e6c5b1d6c8a36fce95e  # HFR
+        #     - 7ba05c6e0e14e793538174c679126996  # MULTi
+        #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+        #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
+        #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        #     - 7470a681e6205243983c4410ee4c920f  # VC-1
+        #     - 90501962793d580d011511155c97e4e5  # VP9
+        #     - cddfb4e32db826151d97352b8e37c648  # x264
+        #     - c9eafd50846d299b862ca9bb6ea91950  # x265
+        #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - e6e299075e22ac8f541f722254c8350a  # AUBC
+        #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
+        #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+      skip:
+        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+        # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-hd-remux-web.yml
+++ b/sonarr/templates/german-hd-remux-web.yml
@@ -16,6 +16,10 @@ sonarr:
 
     custom_format_groups:
       add:
+        - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+          select:
+            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
@@ -47,5 +51,4 @@ sonarr:
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
       skip:
-        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/sonarr/templates/german-uhd-bluray-web-alternative.yml
@@ -16,6 +16,14 @@ sonarr:
 
     custom_format_groups:
       add:
+        - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+          select:
+            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+          select:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
@@ -55,6 +63,4 @@ sonarr:
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
-        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
-        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/sonarr/templates/german-uhd-bluray-web-alternative.yml
@@ -19,11 +19,42 @@ sonarr:
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
-        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        #   select:
+        #     - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+        #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
+        #     - 1bd69272e23c5e6c5b1d6c8a36fce95e  # HFR
+        #     - 7ba05c6e0e14e793538174c679126996  # MULTi
+        #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+        #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
+        #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        #     - 7470a681e6205243983c4410ee4c920f  # VC-1
+        #     - 90501962793d580d011511155c97e4e5  # VP9
+        #     - cddfb4e32db826151d97352b8e37c648  # x264
+        #     - c9eafd50846d299b862ca9bb6ea91950  # x265
+        #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - e6e299075e22ac8f541f722254c8350a  # AUBC
+        #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
+        #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+      skip:
+        # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
+        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+        # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-uhd-bluray-web.yml
+++ b/sonarr/templates/german-uhd-bluray-web.yml
@@ -16,6 +16,14 @@ sonarr:
 
     custom_format_groups:
       add:
+        - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+          select:
+            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+          select:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
@@ -55,6 +63,4 @@ sonarr:
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
-        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
-        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-uhd-bluray-web.yml
+++ b/sonarr/templates/german-uhd-bluray-web.yml
@@ -19,11 +19,42 @@ sonarr:
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
-        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        #   select:
+        #     - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+        #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
+        #     - 1bd69272e23c5e6c5b1d6c8a36fce95e  # HFR
+        #     - 7ba05c6e0e14e793538174c679126996  # MULTi
+        #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+        #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
+        #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        #     - 7470a681e6205243983c4410ee4c920f  # VC-1
+        #     - 90501962793d580d011511155c97e4e5  # VP9
+        #     - cddfb4e32db826151d97352b8e37c648  # x264
+        #     - c9eafd50846d299b862ca9bb6ea91950  # x265
+        #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - e6e299075e22ac8f541f722254c8350a  # AUBC
+        #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
+        #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+      skip:
+        # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
+        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+        # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-uhd-remux-web.yml
+++ b/sonarr/templates/german-uhd-remux-web.yml
@@ -16,6 +16,14 @@ sonarr:
 
     custom_format_groups:
       add:
+        - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+          select:
+            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+          select:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
@@ -55,6 +63,4 @@ sonarr:
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
-        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
-        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-uhd-remux-web.yml
+++ b/sonarr/templates/german-uhd-remux-web.yml
@@ -19,11 +19,42 @@ sonarr:
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
-        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        #   select:
+        #     - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+        #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
+        #     - 1bd69272e23c5e6c5b1d6c8a36fce95e  # HFR
+        #     - 7ba05c6e0e14e793538174c679126996  # MULTi
+        #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+        #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
+        #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        #     - 7470a681e6205243983c4410ee4c920f  # VC-1
+        #     - 90501962793d580d011511155c97e4e5  # VP9
+        #     - cddfb4e32db826151d97352b8e37c648  # x264
+        #     - c9eafd50846d299b862ca9bb6ea91950  # x265
+        #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - e6e299075e22ac8f541f722254c8350a  # AUBC
+        #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
+        #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+      skip:
+        # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
+        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+        # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-1080p-alternative.yml
+++ b/sonarr/templates/web-1080p-alternative.yml
@@ -16,6 +16,10 @@ sonarr:
 
     custom_format_groups:
       add:
+        - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+          select:
+            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
@@ -48,5 +52,4 @@ sonarr:
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
       skip:
-        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-1080p-alternative.yml
+++ b/sonarr/templates/web-1080p-alternative.yml
@@ -17,10 +17,36 @@ sonarr:
     custom_format_groups:
       add:
         # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
-        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        #   select:
+        #     - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+        #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
+        #     - 1bd69272e23c5e6c5b1d6c8a36fce95e  # HFR
+        #     - 7ba05c6e0e14e793538174c679126996  # MULTi
+        #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+        #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
+        #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        #     - 7470a681e6205243983c4410ee4c920f  # VC-1
+        #     - 90501962793d580d011511155c97e4e5  # VP9
+        #     - cddfb4e32db826151d97352b8e37c648  # x264
+        #     - c9eafd50846d299b862ca9bb6ea91950  # x265
+        #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - e6e299075e22ac8f541f722254c8350a  # AUBC
+        #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
+        #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+      skip:
+        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+        # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-1080p.yml
+++ b/sonarr/templates/web-1080p.yml
@@ -16,10 +16,36 @@ sonarr:
 
     custom_format_groups:
       add:
-        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        #   select:
+        #     - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+        #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
+        #     - 1bd69272e23c5e6c5b1d6c8a36fce95e  # HFR
+        #     - 7ba05c6e0e14e793538174c679126996  # MULTi
+        #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+        #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
+        #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        #     - 7470a681e6205243983c4410ee4c920f  # VC-1
+        #     - 90501962793d580d011511155c97e4e5  # VP9
+        #     - cddfb4e32db826151d97352b8e37c648  # x264
+        #     - c9eafd50846d299b862ca9bb6ea91950  # x265
+        #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - e6e299075e22ac8f541f722254c8350a  # AUBC
+        #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
+        #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+      skip:
+        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+        # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-1080p.yml
+++ b/sonarr/templates/web-1080p.yml
@@ -16,6 +16,10 @@ sonarr:
 
     custom_format_groups:
       add:
+        - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+          select:
+            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
@@ -47,5 +51,4 @@ sonarr:
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
       skip:
-        # - 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-2160p-alternative.yml
+++ b/sonarr/templates/web-2160p-alternative.yml
@@ -20,11 +20,41 @@ sonarr:
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
-        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        #   select:
+        #     - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+        #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
+        #     - 1bd69272e23c5e6c5b1d6c8a36fce95e  # HFR
+        #     - 7ba05c6e0e14e793538174c679126996  # MULTi
+        #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+        #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
+        #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        #     - 7470a681e6205243983c4410ee4c920f  # VC-1
+        #     - 90501962793d580d011511155c97e4e5  # VP9
+        #     - cddfb4e32db826151d97352b8e37c648  # x264
+        #     - c9eafd50846d299b862ca9bb6ea91950  # x265
+        #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - e6e299075e22ac8f541f722254c8350a  # AUBC
+        #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
+        #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+      skip:
+        # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
+        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+        # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-2160p-alternative.yml
+++ b/sonarr/templates/web-2160p-alternative.yml
@@ -16,6 +16,10 @@ sonarr:
 
     custom_format_groups:
       add:
+        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+          select:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
@@ -56,5 +60,4 @@ sonarr:
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
-        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-2160p-combined.yml
+++ b/sonarr/templates/web-2160p-combined.yml
@@ -19,11 +19,41 @@ sonarr:
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
-        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        #   select:
+        #     - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+        #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
+        #     - 1bd69272e23c5e6c5b1d6c8a36fce95e  # HFR
+        #     - 7ba05c6e0e14e793538174c679126996  # MULTi
+        #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+        #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
+        #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        #     - 7470a681e6205243983c4410ee4c920f  # VC-1
+        #     - 90501962793d580d011511155c97e4e5  # VP9
+        #     - cddfb4e32db826151d97352b8e37c648  # x264
+        #     - c9eafd50846d299b862ca9bb6ea91950  # x265
+        #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - e6e299075e22ac8f541f722254c8350a  # AUBC
+        #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
+        #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+      skip:
+        # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
+        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+        # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-2160p-combined.yml
+++ b/sonarr/templates/web-2160p-combined.yml
@@ -16,6 +16,10 @@ sonarr:
 
     custom_format_groups:
       add:
+        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+          select:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
@@ -55,5 +59,4 @@ sonarr:
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
-        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-2160p.yml
+++ b/sonarr/templates/web-2160p.yml
@@ -19,11 +19,41 @@ sonarr:
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
-        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
+        #   select:
+        #     - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+        #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
+        #     - 1bd69272e23c5e6c5b1d6c8a36fce95e  # HFR
+        #     - 7ba05c6e0e14e793538174c679126996  # MULTi
+        #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+        #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
+        #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
+        #     - 7470a681e6205243983c4410ee4c920f  # VC-1
+        #     - 90501962793d580d011511155c97e4e5  # VP9
+        #     - cddfb4e32db826151d97352b8e37c648  # x264
+        #     - c9eafd50846d299b862ca9bb6ea91950  # x265
+        #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
+        #   select:
+        #     - e6e299075e22ac8f541f722254c8350a  # AUBC
+        #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
+        #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
+        #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+      skip:
+        # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
+        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+        # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-2160p.yml
+++ b/sonarr/templates/web-2160p.yml
@@ -16,6 +16,10 @@ sonarr:
 
     custom_format_groups:
       add:
+        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
+          select:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
@@ -55,5 +59,4 @@ sonarr:
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
-        # - e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General


### PR DESCRIPTION
## Summary

- Generator now emits `select:` blocks for CF groups containing optional CFs, and a `skip:` section for default groups
- Default groups with CF-level `default: true` (Golden Rule groups) render under `add:` with an explicit `select:` block, surfacing the mutually exclusive CF choice to users
- Added `scripts/README.md` documenting all three CF group rendering categories
- All templates regenerated with the updated script

Relates to recyclarr/recyclarr#722