### PR TITLE
feat: add inline documentation and schema directive to templates

### DIFF
--- a/radarr/templates/anime-remux-1080p.yml
+++ b/radarr/templates/anime-remux-1080p.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [Anime] Remux-1080p
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles-anime/#quality-profile
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [Anime] Remux-1080p
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-
+## anime/#quality-profile
+################################################################################
 
 radarr:
   radarr-anime-remux-1080p:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch

--- a/radarr/templates/french-hd-bluray-web.yml
+++ b/radarr/templates/french-hd-bluray-web.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [French MULTi.VO] HD Bluray + WEB
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#hd-bluray-web-1080p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [French MULTi.VO] HD Bluray + WEB
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#hd-
+## bluray-web-1080p
+################################################################################
 
 radarr:
   french-hd-bluray-web:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
           select:
@@ -71,5 +85,11 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-hd-remux-1080p.yml
+++ b/radarr/templates/french-hd-remux-1080p.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [French MULTi.VO] HD Remux (1080p)
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#hd-remux-1080p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [French MULTi.VO] HD Remux (1080p)
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#hd-
+## remux-1080p
+################################################################################
 
 radarr:
   french-hd-remux-1080p:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
           select:
@@ -75,6 +89,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-uhd-bluray-web.yml
+++ b/radarr/templates/french-uhd-bluray-web.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [French MULTi.VO] UHD Bluray + WEB
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#uhd-bluray-web-2160p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [French MULTi.VO] UHD Bluray + WEB
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-
+## en/#uhd-bluray-web-2160p
+################################################################################
 
 radarr:
   french-uhd-bluray-web:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -78,6 +92,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR

--- a/radarr/templates/french-uhd-remux-2160p.yml
+++ b/radarr/templates/french-uhd-remux-2160p.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [French MULTi.VO] UHD Remux (2160p)
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#uhd-remux-2160p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [French MULTi.VO] UHD Remux (2160p)
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-
+## en/#uhd-remux-2160p
+################################################################################
 
 radarr:
   french-uhd-remux-2160p:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -78,6 +92,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [German] HD Bluray + WEB
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-en/#hd-bluray-web
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [German] HD Bluray + WEB
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-en/#hd-
+## bluray-web
+################################################################################
 
 radarr:
   radarr-german-hd-bluray-web:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
           select:
@@ -71,5 +85,11 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/german-hd-remux-web.yml
+++ b/radarr/templates/german-hd-remux-web.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [German] HD Remux + WEB
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-en/#hd-remux-web
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [German] HD Remux + WEB
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-en/#hd-
+## remux-web
+################################################################################
 
 radarr:
   radarr-german-hd-remux-web:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
           select:
@@ -71,6 +85,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/german-remux-web-2160p.yml
+++ b/radarr/templates/german-remux-web-2160p.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [German] Remux + WEB 2160p
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-en/#uhd-remux-web
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [German] Remux + WEB 2160p
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
+## en/#uhd-remux-web
+################################################################################
 
 radarr:
   german-remux-web-2160p:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -78,6 +92,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR

--- a/radarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/radarr/templates/german-uhd-bluray-web-alternative.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [German] UHD Bluray + WEB (Alternative)
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-en/#uhd-bluray-web
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [German] UHD Bluray + WEB (Alternative)
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
+## en/#uhd-bluray-web
+################################################################################
 
 radarr:
   radarr-german-uhd-bluray-web-alternative:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -78,6 +92,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [German] UHD Bluray + WEB
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-en/#uhd-bluray-web
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [German] UHD Bluray + WEB
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
+## en/#uhd-bluray-web
+################################################################################
 
 radarr:
   radarr-german-uhd-bluray-web:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -78,6 +92,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -1,5 +1,9 @@
-# TRaSH Guides: HD Bluray + WEB
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#hd-bluray-web
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: HD Bluray + WEB
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#hd-bluray-web
+################################################################################
 
 radarr:
   hd-bluray-web:
@@ -15,6 +19,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
           select:
@@ -60,5 +73,11 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/remux-2160p-alternative.yml
+++ b/radarr/templates/remux-2160p-alternative.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: Remux 2160p (Alternative)
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-web-2160p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: Remux 2160p (Alternative)
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-
+## web-2160p
+################################################################################
 
 radarr:
   remux-2160p-alternative:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -67,6 +81,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR

--- a/radarr/templates/remux-2160p-combined.yml
+++ b/radarr/templates/remux-2160p-combined.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: Remux 2160p (Combined)
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-web-2160p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: Remux 2160p (Combined)
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-
+## web-2160p
+################################################################################
 
 radarr:
   remux-2160p-combined:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -67,6 +81,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: Remux + WEB 1080p
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-web-1080p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: Remux + WEB 1080p
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-
+## web-1080p
+################################################################################
 
 radarr:
   remux-web-1080p:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
           select:
@@ -60,6 +74,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: Remux + WEB 2160p
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-web-2160p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: Remux + WEB 2160p
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#remux-
+## web-2160p
+################################################################################
 
 radarr:
   remux-web-2160p:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -67,6 +81,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR

--- a/radarr/templates/sqp/sqp-1-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-1080p.yml
@@ -1,4 +1,7 @@
-# TRaSH Guides: [SQP] SQP-1 (1080p)
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [SQP] SQP-1 (1080p)
+################################################################################
 
 radarr:
   sqp-1-1080p:
@@ -14,6 +17,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -54,5 +66,11 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -1,4 +1,7 @@
-# TRaSH Guides: [SQP] SQP-1 (2160p)
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [SQP] SQP-1 (2160p)
+################################################################################
 
 radarr:
   sqp-1-2160p:
@@ -14,6 +17,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -60,6 +72,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-1-web-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-web-1080p.yml
@@ -1,4 +1,7 @@
-# TRaSH Guides: [SQP] SQP-1 WEB (1080p)
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [SQP] SQP-1 WEB (1080p)
+################################################################################
 
 radarr:
   sqp-1-web-1080p:
@@ -14,6 +17,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -54,5 +66,11 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-1-web-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-web-2160p.yml
@@ -1,4 +1,7 @@
-# TRaSH Guides: [SQP] SQP-1 WEB (2160p)
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [SQP] SQP-1 WEB (2160p)
+################################################################################
 
 radarr:
   sqp-1-web-2160p:
@@ -14,6 +17,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -60,6 +72,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -1,4 +1,7 @@
-# TRaSH Guides: [SQP] SQP-2
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [SQP] SQP-2
+################################################################################
 
 radarr:
   sqp-2:
@@ -14,6 +17,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -64,6 +76,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR

--- a/radarr/templates/sqp/sqp-3-audio.yml
+++ b/radarr/templates/sqp/sqp-3-audio.yml
@@ -1,4 +1,7 @@
-# TRaSH Guides: [SQP] SQP-3 (Audio)
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [SQP] SQP-3 (Audio)
+################################################################################
 
 radarr:
   sqp-3-audio:
@@ -14,6 +17,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -64,6 +76,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
         # - feee39414cb4052dbc55d8752f87e211  # [SQP] Disable if one Radarr

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -1,4 +1,7 @@
-# TRaSH Guides: [SQP] SQP-3
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [SQP] SQP-3
+################################################################################
 
 radarr:
   sqp-3:
@@ -14,6 +17,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -64,6 +76,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -1,4 +1,7 @@
-# TRaSH Guides: [SQP] SQP-4
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [SQP] SQP-4
+################################################################################
 
 radarr:
   sqp-4:
@@ -14,6 +17,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -64,6 +76,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -1,4 +1,7 @@
-# TRaSH Guides: [SQP] SQP-5
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [SQP] SQP-5
+################################################################################
 
 radarr:
   sqp-5:
@@ -14,6 +17,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -64,6 +76,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: UHD Bluray + WEB
-# https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#uhd-bluray-web
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: UHD Bluray + WEB
+##
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles/#uhd-bluray-
+## web
+################################################################################
 
 radarr:
   uhd-bluray-web:
@@ -15,6 +20,15 @@ radarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
           select:
@@ -67,6 +81,12 @@ radarr:
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR

--- a/scripts/generate-template.py
+++ b/scripts/generate-template.py
@@ -18,10 +18,12 @@ import argparse
 import json
 import re
 import sys
+import textwrap
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
 
+COMMENT_BLOCK_WIDTH = 80
 SERVICES = ("radarr", "sonarr")
 
 
@@ -276,13 +278,44 @@ def build_template_specs(guides_path: Path) -> list[TemplateSpec]:
     return specs
 
 
+def comment_block(paragraphs: list[str], indent: int = 0) -> list[str]:
+    """Build a bordered comment block with word-wrapped paragraphs.
+
+    Each string in `paragraphs` becomes a separate paragraph, separated by
+    blank comment lines. Text is wrapped to fit within COMMENT_BLOCK_WIDTH
+    including the `## ` prefix.
+
+    Returns lines with `indent` spaces prepended, ready to append to output.
+    """
+    prefix = "## "
+    text_width = COMMENT_BLOCK_WIDTH - len(prefix)
+    border = "#" * COMMENT_BLOCK_WIDTH
+    pad = " " * indent
+
+    lines = [f"{pad}{border}"]
+    for i, para in enumerate(paragraphs):
+        if i > 0:
+            lines.append(f"{pad}##")
+        for wrapped in textwrap.wrap(para, width=text_width):
+            lines.append(f"{pad}{prefix}{wrapped}")
+    lines.append(f"{pad}{border}")
+    return lines
+
+
 def generate_yaml(spec: TemplateSpec) -> str:
     lines = []
 
+    # Schema directive (must be line 1 for Red Hat YAML extension)
+    lines.append(
+        "# yaml-language-server:"
+        " $schema=https://schemas.recyclarr.dev/v8/config-schema.json"
+    )
+
     # Header
-    lines.append(f"# TRaSH Guides: {spec.profile.name}")
+    header_paras = [f"TRaSH Guides: {spec.profile.name}"]
     if spec.profile.trash_url:
-        lines.append(f"# {spec.profile.trash_url}")
+        header_paras.append(spec.profile.trash_url)
+    lines.extend(comment_block(header_paras))
     lines.append("")
 
     # Instance block
@@ -318,6 +351,20 @@ def generate_yaml(spec: TemplateSpec) -> str:
             simple.sort(key=lambda g: g.name)
             expanded.sort(key=lambda g: g.name)
 
+            lines.extend(
+                comment_block(
+                    [
+                        "These groups are NOT synced by default. Uncomment to"
+                        " enable. Use `select:` to choose specific CFs within"
+                        " a group.",
+                        "To uncomment, remove `# ` (hash + space) so that"
+                        " indentation stays aligned. Most editors do this"
+                        " automatically with toggle-comment (Ctrl+/).",
+                        "https://recyclarr.dev/guide/cf-groups/",
+                    ],
+                    indent=6,
+                )
+            )
             lines.append("      add:")
 
             # Choice groups: uncommented, with select block
@@ -340,6 +387,16 @@ def generate_yaml(spec: TemplateSpec) -> str:
                     lines.append(f"        #     - {cf.trash_id}  # {cf.name}")
 
         if has_default:
+            lines.append("")
+            lines.extend(
+                comment_block(
+                    [
+                        "These groups ARE synced by default. Uncomment to disable.",
+                        "https://recyclarr.dev/guide/cf-groups/",
+                    ],
+                    indent=6,
+                )
+            )
             lines.append("      skip:")
             for group in spec.default_groups:
                 lines.append(f"        # - {group.trash_id}  # {group.name}")

--- a/sonarr/templates/anime-remux-1080p.yml
+++ b/sonarr/templates/anime-remux-1080p.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [Anime] Remux-1080p
-# https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-anime/#quality-profile
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [Anime] Remux-1080p
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-
+## anime/#quality-profile
+################################################################################
 
 sonarr:
   sonarr-anime-remux-1080p:
@@ -15,6 +20,15 @@ sonarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch

--- a/sonarr/templates/french-hd-bluray-web-1080p.yml
+++ b/sonarr/templates/french-hd-bluray-web-1080p.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [French MULTi.VO] HD Bluray + WEB (1080p)
-# https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-french-en/#hd-bluray-web-1080p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [French MULTi.VO] HD Bluray + WEB (1080p)
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-french-en/#hd-
+## bluray-web-1080p
+################################################################################
 
 sonarr:
   french-hd-bluray-web-1080p:
@@ -15,6 +20,15 @@ sonarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
           select:
@@ -49,5 +63,11 @@ sonarr:
         #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/french-uhd-bluray-web-2160p.yml
+++ b/sonarr/templates/french-uhd-bluray-web-2160p.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [French MULTi.VO] UHD Bluray + WEB (2160p)
-# https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-french-en/#uhd-bluray-web-2160p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [French MULTi.VO] UHD Bluray + WEB (2160p)
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-french-
+## en/#uhd-bluray-web-2160p
+################################################################################
 
 sonarr:
   french-uhd-bluray-web-2160p:
@@ -15,6 +20,15 @@ sonarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
           select:
@@ -56,6 +70,12 @@ sonarr:
         #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-hd-bluray-web.yml
+++ b/sonarr/templates/german-hd-bluray-web.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [German] HD Bluray + WEB
-# https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#hd-bluray-web
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [German] HD Bluray + WEB
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#hd-
+## bluray-web
+################################################################################
 
 sonarr:
   sonarr-german-hd-bluray-web:
@@ -15,6 +20,15 @@ sonarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
           select:
@@ -50,5 +64,11 @@ sonarr:
         #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-hd-remux-web.yml
+++ b/sonarr/templates/german-hd-remux-web.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [German] HD Remux + WEB
-# https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#hd-remux-web
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [German] HD Remux + WEB
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#hd-
+## remux-web
+################################################################################
 
 sonarr:
   sonarr-german-hd-remux-web:
@@ -15,6 +20,15 @@ sonarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
           select:
@@ -50,5 +64,11 @@ sonarr:
         #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/sonarr/templates/german-uhd-bluray-web-alternative.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [German] UHD Bluray + WEB (Alternative)
-# https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#uhd-bluray-web-2160p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [German] UHD Bluray + WEB (Alternative)
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-
+## en/#uhd-bluray-web-2160p
+################################################################################
 
 sonarr:
   sonarr-german-uhd-bluray-web-alternative:
@@ -15,6 +20,15 @@ sonarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
           select:
@@ -61,6 +75,12 @@ sonarr:
         #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-uhd-bluray-web.yml
+++ b/sonarr/templates/german-uhd-bluray-web.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [German] UHD Bluray + WEB
-# https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#uhd-bluray-web-2160p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [German] UHD Bluray + WEB
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-
+## en/#uhd-bluray-web-2160p
+################################################################################
 
 sonarr:
   sonarr-german-uhd-bluray-web:
@@ -15,6 +20,15 @@ sonarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
           select:
@@ -61,6 +75,12 @@ sonarr:
         #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-uhd-remux-web.yml
+++ b/sonarr/templates/german-uhd-remux-web.yml
@@ -1,5 +1,10 @@
-# TRaSH Guides: [German] UHD Remux + WEB
-# https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#uhd-remux-web-2160p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [German] UHD Remux + WEB
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-
+## en/#uhd-remux-web-2160p
+################################################################################
 
 sonarr:
   german-uhd-remux-web:
@@ -15,6 +20,15 @@ sonarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
           select:
@@ -61,6 +75,12 @@ sonarr:
         #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-1080p-alternative.yml
+++ b/sonarr/templates/web-1080p-alternative.yml
@@ -1,5 +1,9 @@
-# TRaSH Guides: WEB-1080p (Alternative)
-# https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-1080p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: WEB-1080p (Alternative)
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-1080p
+################################################################################
 
 sonarr:
   web-1080p-alternative:
@@ -15,6 +19,15 @@ sonarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
           select:
@@ -51,5 +64,11 @@ sonarr:
         #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-1080p.yml
+++ b/sonarr/templates/web-1080p.yml
@@ -1,5 +1,9 @@
-# TRaSH Guides: WEB-1080p
-# https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-1080p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: WEB-1080p
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-1080p
+################################################################################
 
 sonarr:
   web-1080p:
@@ -15,6 +19,15 @@ sonarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
           select:
@@ -50,5 +63,11 @@ sonarr:
         #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-2160p-alternative.yml
+++ b/sonarr/templates/web-2160p-alternative.yml
@@ -1,5 +1,9 @@
-# TRaSH Guides: WEB-2160p (Alternative)
-# https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-2160p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: WEB-2160p (Alternative)
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-2160p
+################################################################################
 
 sonarr:
   web-2160p-alternative:
@@ -15,6 +19,15 @@ sonarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
           select:
@@ -58,6 +71,12 @@ sonarr:
         #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-2160p-combined.yml
+++ b/sonarr/templates/web-2160p-combined.yml
@@ -1,5 +1,9 @@
-# TRaSH Guides: WEB-2160p (Combined)
-# https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-2160p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: WEB-2160p (Combined)
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-2160p
+################################################################################
 
 sonarr:
   web-2160p-combined:
@@ -15,6 +19,15 @@ sonarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
           select:
@@ -57,6 +70,12 @@ sonarr:
         #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/web-2160p.yml
+++ b/sonarr/templates/web-2160p.yml
@@ -1,5 +1,9 @@
-# TRaSH Guides: WEB-2160p
-# https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-2160p
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: WEB-2160p
+##
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles/#web-2160p
+################################################################################
 
 sonarr:
   web-2160p:
@@ -15,6 +19,15 @@ sonarr:
           enabled: true
 
     custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
           select:
@@ -57,6 +70,12 @@ sonarr:
         #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
         #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+
+      ################################################################################
+      ## These groups ARE synced by default. Uncomment to disable.
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
       skip:
         # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General


### PR DESCRIPTION
## Summary

- Generator now emits a `yaml-language-server` schema directive on line 1 for Red Hat YAML extension support
- Bordered comment blocks in the header and above `add:`/`skip:` sections explain behavior and link to docs
- Uncomment instructions explain removing `# ` (hash + space) for proper YAML alignment
- Reusable `comment_block()` method handles word-wrapping and border formatting
- All templates regenerated with the updated script