### PR TITLE
fix(scripts): derive template IDs from guide file stems

### DIFF
--- a/radarr/templates/anime-remux-1080p.yml
+++ b/radarr/templates/anime-remux-1080p.yml
@@ -39,9 +39,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/french-multi-vf-hd-bluray-web.yml
+++ b/radarr/templates/french-multi-vf-hd-bluray-web.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
+## TRaSH Guides: [French MULTi.VF] HD Bluray + WEB
 ##
-## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#hd-
+## bluray-web-1080p
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  french-multi-vf-hd-bluray-web:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ radarr:
       type: movie
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: 500ecc23572575511fd81893777d1e06  # [French MULTi.VF] HD Bluray + WEB
         reset_unmatched_scores:
           enabled: true
 
@@ -30,13 +30,10 @@ radarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
           select:
-            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
-        # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
-        # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
+            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,21 +68,17 @@ radarr:
         #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
         #     - eecf3a857724171f968a66cb5719e152  # IMAX
         #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
@@ -100,6 +93,4 @@ radarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       skip:
-        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
-        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-multi-vf-hd-remux-web.yml
+++ b/radarr/templates/french-multi-vf-hd-remux-web.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
+## TRaSH Guides: [French MULTi.VF] HD Remux (1080p)
 ##
-## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#hd-
+## remux-1080p
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  french-multi-vf-hd-remux-web:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ radarr:
       type: movie
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: 6b93fe45f357e9a94228e5d4658e9bb5  # [French MULTi.VF] HD Remux (1080p)
         reset_unmatched_scores:
           enabled: true
 
@@ -30,13 +30,10 @@ radarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
           select:
-            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
-        # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
-        # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
+            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,21 +68,17 @@ radarr:
         #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
         #     - eecf3a857724171f968a66cb5719e152  # IMAX
         #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
@@ -101,5 +94,4 @@ radarr:
       ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
-        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-multi-vf-uhd-bluray-web.yml
+++ b/radarr/templates/french-multi-vf-uhd-bluray-web.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
+## TRaSH Guides: [French MULTi.VF] UHD Bluray + WEB
 ##
-## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-
+## en/#uhd-bluray-web-2160p
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  french-multi-vf-uhd-bluray-web:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ radarr:
       type: movie
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: e64b266178c7f70e208f493f00e0e50a  # [French MULTi.VF] UHD Bluray + WEB
         reset_unmatched_scores:
           enabled: true
 
@@ -75,17 +75,17 @@ radarr:
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
         #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC

--- a/radarr/templates/french-multi-vf-uhd-remux-web.yml
+++ b/radarr/templates/french-multi-vf-uhd-remux-web.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
+## TRaSH Guides: [French MULTi.VF] UHD Remux (2160p)
 ##
-## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-
+## en/#uhd-remux-2160p
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  french-multi-vf-uhd-remux-web:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ radarr:
       type: movie
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: 595bb95c6b6970468880069dce23e1d2  # [French MULTi.VF] UHD Remux (2160p)
         reset_unmatched_scores:
           enabled: true
 
@@ -75,17 +75,17 @@ radarr:
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
         #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC

--- a/radarr/templates/french-multi-vo-hd-bluray-web.yml
+++ b/radarr/templates/french-multi-vo-hd-bluray-web.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
+## TRaSH Guides: [French MULTi.VO] HD Bluray + WEB
 ##
-## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#hd-
+## bluray-web-1080p
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  french-multi-vo-hd-bluray-web:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ radarr:
       type: movie
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: 2572ce3ea4eef1c19d59e0e20ed1cea7  # [French MULTi.VO] HD Bluray + WEB
         reset_unmatched_scores:
           enabled: true
 
@@ -30,13 +30,10 @@ radarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
           select:
-            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
-        # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
-        # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
+            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,21 +68,17 @@ radarr:
         #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
         #     - eecf3a857724171f968a66cb5719e152  # IMAX
         #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
@@ -100,6 +93,4 @@ radarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       skip:
-        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
-        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-multi-vo-hd-remux-web.yml
+++ b/radarr/templates/french-multi-vo-hd-remux-web.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
+## TRaSH Guides: [French MULTi.VO] HD Remux (1080p)
 ##
-## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#hd-
+## remux-1080p
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  french-multi-vo-hd-remux-web:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ radarr:
       type: movie
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: c6460a102b312200c095a2d0982e0461  # [French MULTi.VO] HD Remux (1080p)
         reset_unmatched_scores:
           enabled: true
 
@@ -30,13 +30,10 @@ radarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
           select:
-            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
-        # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
-        # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
+            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,21 +68,17 @@ radarr:
         #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
         #     - eecf3a857724171f968a66cb5719e152  # IMAX
         #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
@@ -101,5 +94,4 @@ radarr:
       ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
-        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-multi-vo-uhd-bluray-web.yml
+++ b/radarr/templates/french-multi-vo-uhd-bluray-web.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
+## TRaSH Guides: [French MULTi.VO] UHD Bluray + WEB
 ##
-## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-
+## en/#uhd-bluray-web-2160p
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  french-multi-vo-uhd-bluray-web:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ radarr:
       type: movie
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: 92ead7022d13a7858d54e328e6a2f8f9  # [French MULTi.VO] UHD Bluray + WEB
         reset_unmatched_scores:
           enabled: true
 
@@ -75,17 +75,17 @@ radarr:
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
         #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC

--- a/radarr/templates/french-multi-vo-uhd-remux-web.yml
+++ b/radarr/templates/french-multi-vo-uhd-remux-web.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
+## TRaSH Guides: [French MULTi.VO] UHD Remux (2160p)
 ##
-## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-
+## en/#uhd-remux-2160p
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  french-multi-vo-uhd-remux-web:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ radarr:
       type: movie
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: 1fef28c8c919f31cd86283b1baf527d4  # [French MULTi.VO] UHD Remux (2160p)
         reset_unmatched_scores:
           enabled: true
 
@@ -75,17 +75,17 @@ radarr:
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
         #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC

--- a/radarr/templates/french-vostfr-hd-bluray-web.yml
+++ b/radarr/templates/french-vostfr-hd-bluray-web.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
+## TRaSH Guides: [French VOSTFR] HD Bluray + WEB
 ##
-## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#hd-
+## bluray-web-1080p
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  french-vostfr-hd-bluray-web:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ radarr:
       type: movie
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: 1addc08c4232bc2617684d517df15f75  # [French VOSTFR] HD Bluray + WEB
         reset_unmatched_scores:
           enabled: true
 
@@ -30,13 +30,10 @@ radarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
           select:
-            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
-        # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
-        # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
+            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,21 +68,17 @@ radarr:
         #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
         #     - eecf3a857724171f968a66cb5719e152  # IMAX
         #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
@@ -100,6 +93,4 @@ radarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       skip:
-        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
-        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-vostfr-hd-remux-web.yml
+++ b/radarr/templates/french-vostfr-hd-remux-web.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
+## TRaSH Guides: [French VOSTFR] HD Remux (1080p)
 ##
-## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-en/#hd-
+## remux-1080p
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  french-vostfr-hd-remux-web:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ radarr:
       type: movie
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: d98f20924b001e9f6b9595d5440abc87  # [French VOSTFR] HD Remux (1080p)
         reset_unmatched_scores:
           enabled: true
 
@@ -30,13 +30,10 @@ radarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Required] Golden Rule UHD
+        - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Required] Golden Rule HD
           select:
-            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
-        # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
-        # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
+            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,21 +68,17 @@ radarr:
         #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
         #     - eecf3a857724171f968a66cb5719e152  # IMAX
         #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
@@ -101,5 +94,4 @@ radarr:
       ################################################################################
       skip:
         # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
-        # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/french-vostfr-uhd-bluray-web.yml
+++ b/radarr/templates/french-vostfr-uhd-bluray-web.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
+## TRaSH Guides: [French VOSTFR] UHD Bluray + WEB
 ##
-## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-
+## en/#uhd-bluray-web-2160p
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  french-vostfr-uhd-bluray-web:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ radarr:
       type: movie
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: 525bf0513e2ac22fe116e8d7bec0a6b5  # [French VOSTFR] UHD Bluray + WEB
         reset_unmatched_scores:
           enabled: true
 
@@ -75,17 +75,17 @@ radarr:
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
         #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC

--- a/radarr/templates/french-vostfr-uhd-remux-web.yml
+++ b/radarr/templates/french-vostfr-uhd-remux-web.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
+## TRaSH Guides: [French VOSTFR] UHD Remux (2160p)
 ##
-## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-french-
+## en/#uhd-remux-2160p
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  french-vostfr-uhd-remux-web:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ radarr:
       type: movie
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: 9b32fc61d8ec83ed131f50f1db80505a  # [French VOSTFR] UHD Remux (2160p)
         reset_unmatched_scores:
           enabled: true
 
@@ -75,17 +75,17 @@ radarr:
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
         #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
+        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
         #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
+        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
+        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
+        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
+        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
+        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
+        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
+        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
+        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
+        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC

--- a/radarr/templates/german-anime-hd-bluray-web.yml
+++ b/radarr/templates/german-anime-hd-bluray-web.yml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [German] Anime HD Bluray + WEB
+################################################################################
+
+radarr:
+  radarr-german-anime-hd-bluray-web:
+    base_url: Put your Radarr URL here
+    api_key: Put your API key here
+
+    quality_definition:
+      type: movie
+
+    quality_profiles:
+      - trash_id: bf3cc2e99ad9a804a9b0d0e538e1fbba  # [German] Anime HD Bluray + WEB
+        reset_unmatched_scores:
+          enabled: true
+
+    custom_format_groups:
+      ################################################################################
+      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
+      ## choose specific CFs within a group.
+      ##
+      ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
+      ## Most editors do this automatically with toggle-comment (Ctrl+/).
+      ##
+      ## https://recyclarr.dev/guide/cf-groups/
+      ################################################################################
+      add:
+        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
+        #   select:
+        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
+        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
+        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
+        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
+        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
+        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
+        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
+        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
+        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -34,7 +34,7 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
+        # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
@@ -44,9 +44,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/german-hd-remux-web.yml
+++ b/radarr/templates/german-hd-remux-web.yml
@@ -34,7 +34,7 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
+        # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
@@ -44,9 +44,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/radarr/templates/german-uhd-bluray-web-alternative.yml
@@ -37,7 +37,7 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
+        # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
@@ -47,9 +47,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
+## TRaSH Guides: [German] Remux + WEB 2160p
 ##
 ## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## en/#uhd-remux-web
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  radarr-german-uhd-remux-web:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ radarr:
       type: movie
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: 79faa9943cef2f510b997b1f2a9f3ea6  # [German] Remux + WEB 2160p
         reset_unmatched_scores:
           enabled: true
 

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -33,7 +33,7 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
+        # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
@@ -43,9 +43,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/remux-2160p-alternative.yml
+++ b/radarr/templates/remux-2160p-alternative.yml
@@ -37,7 +37,7 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
+        # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
@@ -47,9 +47,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/remux-2160p-combined.yml
+++ b/radarr/templates/remux-2160p-combined.yml
@@ -37,7 +37,7 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
+        # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
@@ -47,9 +47,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -34,7 +34,7 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
+        # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
@@ -44,9 +44,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -37,7 +37,7 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
+        # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
@@ -47,9 +47,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/sqp/sqp-1-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-1080p.yml
@@ -36,9 +36,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -38,9 +38,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/sqp/sqp-1-web-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-web-1080p.yml
@@ -36,9 +36,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/sqp/sqp-1-web-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-web-2160p.yml
@@ -38,9 +38,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -43,9 +43,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/sqp/sqp-3-audio.yml
+++ b/radarr/templates/sqp/sqp-3-audio.yml
@@ -43,9 +43,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -43,9 +43,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/sqp/sqp-4-ma-hybrid.yml
+++ b/radarr/templates/sqp/sqp-4-ma-hybrid.yml
@@ -1,21 +1,18 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Bluray + WEB
-##
-## https://trash-guides.info/Radarr/radarr-setup-quality-profiles-german-
-## en/#uhd-bluray-web
+## TRaSH Guides: [SQP] SQP-4 (MA Hybrid)
 ################################################################################
 
 radarr:
-  radarr-german-uhd-bluray-web:
+  sqp-4-ma-hybrid:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
     quality_definition:
-      type: movie
+      type: sqp-uhd
 
     quality_profiles:
-      - trash_id: 27cc3d153c0a799fd139ef1ff4c4cc42  # [German] UHD Bluray + WEB
+      - trash_id: 7526db7ac0a1f764793fb181864d0222  # [SQP] SQP-4 (MA Hybrid)
         reset_unmatched_scores:
           enabled: true
 
@@ -37,11 +34,9 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
-        # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
-        # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
+        # - trash_id: c4492eebd0c2ddc14c2c91623aa7f95d  # [Optional] Miscellaneous SQP
         #   select:
         #     - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
@@ -55,7 +50,6 @@ radarr:
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1
         #     - ae4cfaa9283a4f2150ac3da08e388723  # VP9
-        #     - 2899d84dc9372de3408e6d8cc18e9666  # x264
         #     - 9170d55c319f4fe40da8711ba9d8050d  # x265
         #     - 390455c22a9cac81a738f6cbad705c3c  # x266
         # - trash_id: f4f1474b963b24cf983455743aa9906c  # [Optional] Movie Versions
@@ -71,21 +65,15 @@ radarr:
         #     - 0f12c086e289cf966fa5948eac571f44  # Hybrid
         #     - eecf3a857724171f968a66cb5719e152  # IMAX
         #     - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
+        # - trash_id: f638e33c933bf0a8067559247953a270  # [SQP-4 (MA Hybrid) Optional] Release Groups
+        #   select:
+        #     - e098247bc6652dd88c76644b275260ed  # FLUX
+        #     - 8cd3ac70db7ac318cf9a0e01333940a4  # SiC
+        #     - 9681750c690210f0936faed781bb7f06  # 126811
+        #     - 8016f2f66e751dea613e6b5b94bf633c  # MainFrame
+        # - trash_id: 19b55e2ab8b6c05d11858236ef5c93a9  # [SQP-4 (MA Hybrid) Optional] SDR
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
@@ -100,6 +88,5 @@ radarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       skip:
-        # - 9d5acd8f1da78dfbae788182f7605200  # [Audio] Audio Formats
         # - ef20e67b95a381fb3bc6d1f06ea24f46  # [HDR Formats] HDR
         # - d9cc9a504e5ede6294c8b973aad4f028  # [Streaming Services] General

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -43,9 +43,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -43,9 +43,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -37,7 +37,7 @@ radarr:
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
-        # - trash_id: 60f6d50cbd3cfc3e9a8c00e3a30c3114  # [Streaming Services] Anime
+        # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
@@ -47,9 +47,10 @@ radarr:
         #     - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
         #     - 73613461ac2cea99d52c4cd6e177ab82  # HFR
-        #     - 4b900e171accbfb172729b63323ea8ca  # Multi
+        #     - 4b900e171accbfb172729b63323ea8ca  # MULTi
         #     - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
         #     - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+        #     - 80f51de4636a294e31552e90d2e1decb  # P2P Internal
         #     - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
         #     - f537cf427b64c38c8e36298f657e4828  # Scene
         #     - 11cd1db7165d6a7ad9a83bc97b8b1060  # VC-1

--- a/scripts/generate-template.py
+++ b/scripts/generate-template.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 import textwrap
 from collections import Counter
@@ -180,27 +179,8 @@ def get_groups_for_profile(
     return result
 
 
-def derive_base_id(profile: QualityProfile, group_name: str | None) -> str:
-    name = profile.name
-
-    # Remove bracketed prefixes like [French MULTi.VO], [SQP]
-    name = re.sub(r"\[.*?\]\s*", "", name)
-    # Replace spaces, underscores, dots with hyphens
-    name = re.sub(r"[\s_.]+", "-", name)
-    # Convert parenthesized content to suffix: "SQP-1 (2160p)" -> "sqp-1-2160p"
-    name = re.sub(r"\(([^)]+)\)", r"-\1", name)
-    # Remove remaining special characters
-    name = re.sub(r"[^a-zA-Z0-9-]", "", name)
-    # Collapse multiple hyphens, strip edges, lowercase
-    name = re.sub(r"-+", "-", name).strip("-").lower()
-
-    # Add group prefix for non-standard groups
-    if group_name and group_name.lower() not in ["standard"]:
-        prefix = group_name.lower()
-        if not name.startswith(prefix):
-            name = f"{prefix}-{name}"
-
-    return name
+def derive_base_id(profile: QualityProfile) -> str:
+    return profile.file_stem
 
 
 def derive_output_path(service: str, base_id: str, group_name: str | None) -> str:
@@ -240,7 +220,7 @@ def build_template_specs(guides_path: Path) -> list[TemplateSpec]:
 
         for profile in sorted(profiles.values(), key=lambda p: p.file_stem):
             group_name = get_profile_group_name(profile_groups, profile.trash_id)
-            base_id = derive_base_id(profile, group_name)
+            base_id = derive_base_id(profile)
             optional = get_groups_for_profile(
                 cf_groups, profile.trash_id, default=False
             )

--- a/sonarr/templates/anime-remux-1080p.yml
+++ b/sonarr/templates/anime-remux-1080p.yml
@@ -42,6 +42,7 @@ sonarr:
         #     - 7ba05c6e0e14e793538174c679126996  # MULTi
         #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
         #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 09654d13ce1f0453496546dfd875b2a5  # P2P Internal
         #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
         #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
         #     - 7470a681e6205243983c4410ee4c920f  # VC-1

--- a/sonarr/templates/french-multi-vf-bluray-web-1080p.yml
+++ b/sonarr/templates/french-multi-vf-bluray-web-1080p.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] HD Remux + WEB
+## TRaSH Guides: [French MULTi.VF] HD Bluray + WEB (1080p)
 ##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#hd-
-## remux-web
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-french-en/#hd-
+## bluray-web-1080p
 ################################################################################
 
 sonarr:
-  sonarr-german-hd-remux-web:
+  french-multi-vf-bluray-web-1080p:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 0dd5f085ed61a1e01f6d347779dfa1bc  # [German] HD Remux + WEB
+      - trash_id: 58e8dc75731040612dd6f4ac0676bfd7  # [French MULTi.VF] HD Bluray + WEB (1080p)
         reset_unmatched_scores:
           enabled: true
 

--- a/sonarr/templates/french-multi-vf-bluray-web-2160p.yml
+++ b/sonarr/templates/french-multi-vf-bluray-web-2160p.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] HD Remux + WEB
+## TRaSH Guides: [French MULTi.VF] UHD Bluray + WEB (2160p)
 ##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#hd-
-## remux-web
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-french-
+## en/#uhd-bluray-web-2160p
 ################################################################################
 
 sonarr:
-  sonarr-german-hd-remux-web:
+  french-multi-vf-bluray-web-2160p:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 0dd5f085ed61a1e01f6d347779dfa1bc  # [German] HD Remux + WEB
+      - trash_id: 68c8b82ad2b7ea1941fce71eb56421c3  # [French MULTi.VF] UHD Bluray + WEB (2160p)
         reset_unmatched_scores:
           enabled: true
 
@@ -30,10 +30,13 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
           select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
+        # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
+        # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
@@ -55,6 +58,10 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
@@ -72,4 +79,5 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       skip:
+        # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/french-multi-vo-bluray-web-1080p.yml
+++ b/sonarr/templates/french-multi-vo-bluray-web-1080p.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] HD Remux + WEB
+## TRaSH Guides: [French MULTi.VO] HD Bluray + WEB (1080p)
 ##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#hd-
-## remux-web
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-french-en/#hd-
+## bluray-web-1080p
 ################################################################################
 
 sonarr:
-  sonarr-german-hd-remux-web:
+  french-multi-vo-bluray-web-1080p:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 0dd5f085ed61a1e01f6d347779dfa1bc  # [German] HD Remux + WEB
+      - trash_id: 4c48f506c1116a3a57ae33f12346bd15  # [French MULTi.VO] HD Bluray + WEB (1080p)
         reset_unmatched_scores:
           enabled: true
 

--- a/sonarr/templates/french-multi-vo-bluray-web-2160p.yml
+++ b/sonarr/templates/french-multi-vo-bluray-web-2160p.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] HD Remux + WEB
+## TRaSH Guides: [French MULTi.VO] UHD Bluray + WEB (2160p)
 ##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#hd-
-## remux-web
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-french-
+## en/#uhd-bluray-web-2160p
 ################################################################################
 
 sonarr:
-  sonarr-german-hd-remux-web:
+  french-multi-vo-bluray-web-2160p:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 0dd5f085ed61a1e01f6d347779dfa1bc  # [German] HD Remux + WEB
+      - trash_id: 6fa7364373e8f06206871d9c20a4fb3e  # [French MULTi.VO] UHD Bluray + WEB (2160p)
         reset_unmatched_scores:
           enabled: true
 
@@ -30,10 +30,13 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
           select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
+        # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
+        # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
@@ -55,6 +58,10 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
@@ -72,4 +79,5 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       skip:
+        # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/french-vostfr-bluray-web-1080p.yml
+++ b/sonarr/templates/french-vostfr-bluray-web-1080p.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] HD Remux + WEB
+## TRaSH Guides: [French VOSTFR] HD Bluray + WEB (1080p)
 ##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#hd-
-## remux-web
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-french-en/#hd-
+## bluray-web-1080p
 ################################################################################
 
 sonarr:
-  sonarr-german-hd-remux-web:
+  french-vostfr-bluray-web-1080p:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 0dd5f085ed61a1e01f6d347779dfa1bc  # [German] HD Remux + WEB
+      - trash_id: b34c968f58433a38e0e690d42a1dc37e  # [French VOSTFR] HD Bluray + WEB (1080p)
         reset_unmatched_scores:
           enabled: true
 

--- a/sonarr/templates/french-vostfr-bluray-web-2160p.yml
+++ b/sonarr/templates/french-vostfr-bluray-web-2160p.yml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] HD Remux + WEB
+## TRaSH Guides: [French VOSTFR] UHD Bluray + WEB (2160p)
 ##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-en/#hd-
-## remux-web
+## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-french-
+## en/#uhd-bluray-web-2160p
 ################################################################################
 
 sonarr:
-  sonarr-german-hd-remux-web:
+  french-vostfr-bluray-web-2160p:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +15,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 0dd5f085ed61a1e01f6d347779dfa1bc  # [German] HD Remux + WEB
+      - trash_id: d6252dce6af535107ed4b03e68052ae8  # [French VOSTFR] UHD Bluray + WEB (2160p)
         reset_unmatched_scores:
           enabled: true
 
@@ -30,10 +30,13 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: 158188097a58d7687dee647e04af0da3  # [Required] Golden Rule HD
+        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Required] Golden Rule UHD
           select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
+        # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
+        # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
@@ -55,6 +58,10 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
@@ -72,4 +79,5 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       skip:
+        # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/german-anime-hd-bluray-web.yml
+++ b/sonarr/templates/german-anime-hd-bluray-web.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
+################################################################################
+## TRaSH Guides: [German] Anime HD Bluray + WEB
+################################################################################
+
+sonarr:
+  sonarr-german-anime-hd-bluray-web:
+    base_url: Put your Sonarr URL here
+    api_key: Put your API key here
+
+    quality_definition:
+      type: series
+
+    quality_profiles:
+      - trash_id: 6fe5937e1dcc2269e23b49eb46dfe6d6  # [German] Anime HD Bluray + WEB
+        reset_unmatched_scores:
+          enabled: true

--- a/sonarr/templates/german-hd-bluray-web.yml
+++ b/sonarr/templates/german-hd-bluray-web.yml
@@ -47,6 +47,7 @@ sonarr:
         #     - 7ba05c6e0e14e793538174c679126996  # MULTi
         #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
         #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 09654d13ce1f0453496546dfd875b2a5  # P2P Internal
         #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
         #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
         #     - 7470a681e6205243983c4410ee4c920f  # VC-1

--- a/sonarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/sonarr/templates/german-uhd-bluray-web-alternative.yml
@@ -54,6 +54,7 @@ sonarr:
         #     - 7ba05c6e0e14e793538174c679126996  # MULTi
         #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
         #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 09654d13ce1f0453496546dfd875b2a5  # P2P Internal
         #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
         #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
         #     - 7470a681e6205243983c4410ee4c920f  # VC-1

--- a/sonarr/templates/german-uhd-bluray-web.yml
+++ b/sonarr/templates/german-uhd-bluray-web.yml
@@ -54,6 +54,7 @@ sonarr:
         #     - 7ba05c6e0e14e793538174c679126996  # MULTi
         #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
         #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 09654d13ce1f0453496546dfd875b2a5  # P2P Internal
         #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
         #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
         #     - 7470a681e6205243983c4410ee4c920f  # VC-1

--- a/sonarr/templates/german-uhd-remux-web.yml
+++ b/sonarr/templates/german-uhd-remux-web.yml
@@ -7,7 +7,7 @@
 ################################################################################
 
 sonarr:
-  german-uhd-remux-web:
+  sonarr-german-uhd-remux-web:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -54,6 +54,7 @@ sonarr:
         #     - 7ba05c6e0e14e793538174c679126996  # MULTi
         #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
         #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 09654d13ce1f0453496546dfd875b2a5  # P2P Internal
         #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
         #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
         #     - 7470a681e6205243983c4410ee4c920f  # VC-1

--- a/sonarr/templates/web-1080p-alternative.yml
+++ b/sonarr/templates/web-1080p-alternative.yml
@@ -47,6 +47,7 @@ sonarr:
         #     - 7ba05c6e0e14e793538174c679126996  # MULTi
         #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
         #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 09654d13ce1f0453496546dfd875b2a5  # P2P Internal
         #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
         #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
         #     - 7470a681e6205243983c4410ee4c920f  # VC-1

--- a/sonarr/templates/web-1080p.yml
+++ b/sonarr/templates/web-1080p.yml
@@ -46,6 +46,7 @@ sonarr:
         #     - 7ba05c6e0e14e793538174c679126996  # MULTi
         #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
         #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 09654d13ce1f0453496546dfd875b2a5  # P2P Internal
         #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
         #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
         #     - 7470a681e6205243983c4410ee4c920f  # VC-1

--- a/sonarr/templates/web-2160p-alternative.yml
+++ b/sonarr/templates/web-2160p-alternative.yml
@@ -50,6 +50,7 @@ sonarr:
         #     - 7ba05c6e0e14e793538174c679126996  # MULTi
         #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
         #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 09654d13ce1f0453496546dfd875b2a5  # P2P Internal
         #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
         #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
         #     - 7470a681e6205243983c4410ee4c920f  # VC-1

--- a/sonarr/templates/web-2160p-combined.yml
+++ b/sonarr/templates/web-2160p-combined.yml
@@ -49,6 +49,7 @@ sonarr:
         #     - 7ba05c6e0e14e793538174c679126996  # MULTi
         #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
         #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 09654d13ce1f0453496546dfd875b2a5  # P2P Internal
         #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
         #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
         #     - 7470a681e6205243983c4410ee4c920f  # VC-1

--- a/sonarr/templates/web-2160p.yml
+++ b/sonarr/templates/web-2160p.yml
@@ -49,6 +49,7 @@ sonarr:
         #     - 7ba05c6e0e14e793538174c679126996  # MULTi
         #     - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
         #     - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+        #     - 09654d13ce1f0453496546dfd875b2a5  # P2P Internal
         #     - 06d66ab109d4d2eddb2794d21526d140  # Retags
         #     - 1b3994c551cbb92a2c781af061f4ab44  # Scene
         #     - 7470a681e6205243983c4410ee4c920f  # VC-1

--- a/templates.json
+++ b/templates.json
@@ -1,24 +1,52 @@
 {
   "radarr": [
     {
-      "template": "radarr/templates/french-hd-bluray-web.yml",
-      "id": "french-hd-bluray-web"
+      "template": "radarr/templates/french-multi-vf-hd-bluray-web.yml",
+      "id": "french-multi-vf-hd-bluray-web"
     },
     {
-      "template": "radarr/templates/french-hd-remux-1080p.yml",
-      "id": "french-hd-remux-1080p"
+      "template": "radarr/templates/french-multi-vf-hd-remux-web.yml",
+      "id": "french-multi-vf-hd-remux-web"
     },
     {
-      "template": "radarr/templates/french-uhd-bluray-web.yml",
-      "id": "french-uhd-bluray-web"
+      "template": "radarr/templates/french-multi-vf-uhd-bluray-web.yml",
+      "id": "french-multi-vf-uhd-bluray-web"
     },
     {
-      "template": "radarr/templates/french-uhd-remux-2160p.yml",
-      "id": "french-uhd-remux-2160p"
+      "template": "radarr/templates/french-multi-vf-uhd-remux-web.yml",
+      "id": "french-multi-vf-uhd-remux-web"
     },
     {
-      "template": "radarr/templates/german-remux-web-2160p.yml",
-      "id": "german-remux-web-2160p"
+      "template": "radarr/templates/french-multi-vo-hd-bluray-web.yml",
+      "id": "french-multi-vo-hd-bluray-web"
+    },
+    {
+      "template": "radarr/templates/french-multi-vo-hd-remux-web.yml",
+      "id": "french-multi-vo-hd-remux-web"
+    },
+    {
+      "template": "radarr/templates/french-multi-vo-uhd-bluray-web.yml",
+      "id": "french-multi-vo-uhd-bluray-web"
+    },
+    {
+      "template": "radarr/templates/french-multi-vo-uhd-remux-web.yml",
+      "id": "french-multi-vo-uhd-remux-web"
+    },
+    {
+      "template": "radarr/templates/french-vostfr-hd-bluray-web.yml",
+      "id": "french-vostfr-hd-bluray-web"
+    },
+    {
+      "template": "radarr/templates/french-vostfr-hd-remux-web.yml",
+      "id": "french-vostfr-hd-remux-web"
+    },
+    {
+      "template": "radarr/templates/french-vostfr-uhd-bluray-web.yml",
+      "id": "french-vostfr-uhd-bluray-web"
+    },
+    {
+      "template": "radarr/templates/french-vostfr-uhd-remux-web.yml",
+      "id": "french-vostfr-uhd-remux-web"
     },
     {
       "template": "radarr/templates/hd-bluray-web.yml",
@@ -27,6 +55,10 @@
     {
       "template": "radarr/templates/anime-remux-1080p.yml",
       "id": "radarr-anime-remux-1080p"
+    },
+    {
+      "template": "radarr/templates/german-anime-hd-bluray-web.yml",
+      "id": "radarr-german-anime-hd-bluray-web"
     },
     {
       "template": "radarr/templates/german-hd-bluray-web.yml",
@@ -43,6 +75,10 @@
     {
       "template": "radarr/templates/german-uhd-bluray-web-alternative.yml",
       "id": "radarr-german-uhd-bluray-web-alternative"
+    },
+    {
+      "template": "radarr/templates/german-uhd-remux-web.yml",
+      "id": "radarr-german-uhd-remux-web"
     },
     {
       "template": "radarr/templates/remux-2160p-alternative.yml",
@@ -93,6 +129,10 @@
       "id": "sqp-4"
     },
     {
+      "template": "radarr/templates/sqp/sqp-4-ma-hybrid.yml",
+      "id": "sqp-4-ma-hybrid"
+    },
+    {
       "template": "radarr/templates/sqp/sqp-5.yml",
       "id": "sqp-5"
     },
@@ -103,20 +143,36 @@
   ],
   "sonarr": [
     {
-      "template": "sonarr/templates/french-hd-bluray-web-1080p.yml",
-      "id": "french-hd-bluray-web-1080p"
+      "template": "sonarr/templates/french-multi-vf-bluray-web-1080p.yml",
+      "id": "french-multi-vf-bluray-web-1080p"
     },
     {
-      "template": "sonarr/templates/french-uhd-bluray-web-2160p.yml",
-      "id": "french-uhd-bluray-web-2160p"
+      "template": "sonarr/templates/french-multi-vf-bluray-web-2160p.yml",
+      "id": "french-multi-vf-bluray-web-2160p"
     },
     {
-      "template": "sonarr/templates/german-uhd-remux-web.yml",
-      "id": "german-uhd-remux-web"
+      "template": "sonarr/templates/french-multi-vo-bluray-web-1080p.yml",
+      "id": "french-multi-vo-bluray-web-1080p"
+    },
+    {
+      "template": "sonarr/templates/french-multi-vo-bluray-web-2160p.yml",
+      "id": "french-multi-vo-bluray-web-2160p"
+    },
+    {
+      "template": "sonarr/templates/french-vostfr-bluray-web-1080p.yml",
+      "id": "french-vostfr-bluray-web-1080p"
+    },
+    {
+      "template": "sonarr/templates/french-vostfr-bluray-web-2160p.yml",
+      "id": "french-vostfr-bluray-web-2160p"
     },
     {
       "template": "sonarr/templates/anime-remux-1080p.yml",
       "id": "sonarr-anime-remux-1080p"
+    },
+    {
+      "template": "sonarr/templates/german-anime-hd-bluray-web.yml",
+      "id": "sonarr-german-anime-hd-bluray-web"
     },
     {
       "template": "sonarr/templates/german-hd-bluray-web.yml",
@@ -133,6 +189,10 @@
     {
       "template": "sonarr/templates/german-uhd-bluray-web-alternative.yml",
       "id": "sonarr-german-uhd-bluray-web-alternative"
+    },
+    {
+      "template": "sonarr/templates/german-uhd-remux-web.yml",
+      "id": "sonarr-german-uhd-remux-web"
     },
     {
       "template": "sonarr/templates/web-1080p.yml",


### PR DESCRIPTION
## Summary

- Fixed a bug where French template variants (MULTi.VF, MULTi.VO, VOSTFR) collapsed to the same
  template ID, causing them to silently overwrite each other during generation.
- Regenerated all templates to sync with current TRaSH Guides data.

Fixes #172