### PR TITLE
feat!: sync templates with TRaSH Guides

### DIFF
--- a/radarr/templates/anime-remux-1080p.yml
+++ b/radarr/templates/anime-remux-1080p.yml
@@ -39,6 +39,19 @@ radarr:
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -57,6 +70,7 @@ radarr:
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vf-hd-bluray-web.yml
+++ b/radarr/templates/french-multi-vf-hd-bluray-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,22 +88,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vf-hd-remux-web.yml
+++ b/radarr/templates/french-multi-vf-hd-remux-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,22 +88,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vf-uhd-bluray-web.yml
+++ b/radarr/templates/french-multi-vf-uhd-bluray-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -41,6 +58,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -74,26 +95,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vf-uhd-remux-web.yml
+++ b/radarr/templates/french-multi-vf-uhd-remux-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -41,6 +58,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -74,26 +95,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vo-hd-bluray-web.yml
+++ b/radarr/templates/french-multi-vo-hd-bluray-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,22 +88,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vo-hd-remux-web.yml
+++ b/radarr/templates/french-multi-vo-hd-remux-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,22 +88,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vo-uhd-bluray-web.yml
+++ b/radarr/templates/french-multi-vo-uhd-bluray-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -41,6 +58,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -74,26 +95,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vo-uhd-remux-web.yml
+++ b/radarr/templates/french-multi-vo-uhd-remux-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -41,6 +58,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -74,26 +95,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-vostfr-hd-bluray-web.yml
+++ b/radarr/templates/french-vostfr-hd-bluray-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,22 +88,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-vostfr-hd-remux-web.yml
+++ b/radarr/templates/french-vostfr-hd-remux-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,22 +88,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-vostfr-uhd-bluray-web.yml
+++ b/radarr/templates/french-vostfr-uhd-bluray-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -41,6 +58,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -74,26 +95,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-vostfr-uhd-remux-web.yml
+++ b/radarr/templates/french-vostfr-uhd-remux-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -41,6 +58,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -74,26 +95,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/german-anime-hd-bluray-web.yml
+++ b/radarr/templates/german-anime-hd-bluray-web.yml
@@ -27,23 +27,25 @@ radarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+        - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
           select:
             - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
             - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            # - f537cf427b64c38c8e36298f657e4828  # Scene
             - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
+        # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -71,14 +73,3 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -34,21 +34,22 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+        - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
           select:
             - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
             - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            # - f537cf427b64c38c8e36298f657e4828  # Scene
             - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
@@ -88,21 +89,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/german-hd-remux-web.yml
+++ b/radarr/templates/german-hd-remux-web.yml
@@ -34,21 +34,22 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+        - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
           select:
             - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
             - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            # - f537cf427b64c38c8e36298f657e4828  # Scene
             - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
@@ -88,21 +89,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/radarr/templates/german-uhd-bluray-web-alternative.yml
@@ -34,21 +34,22 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+        - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
           select:
             - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
             - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            # - f537cf427b64c38c8e36298f657e4828  # Scene
             - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
@@ -58,6 +59,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -91,25 +96,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -34,21 +34,22 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+        - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
           select:
             - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
             - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            # - f537cf427b64c38c8e36298f657e4828  # Scene
             - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
@@ -58,6 +59,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -91,25 +96,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -34,21 +34,22 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+        - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
           select:
             - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
             - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            # - f537cf427b64c38c8e36298f657e4828  # Scene
             - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
@@ -58,6 +59,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -91,25 +96,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -42,6 +42,7 @@ radarr:
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
@@ -60,6 +61,19 @@ radarr:
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -91,6 +105,7 @@ radarr:
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/remux-2160p-alternative.yml
+++ b/radarr/templates/remux-2160p-alternative.yml
@@ -7,7 +7,7 @@
 ################################################################################
 
 radarr:
-  remux-2160p-alternative:
+  radarr-remux-2160p-alternative:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -43,6 +43,7 @@ radarr:
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
@@ -58,12 +59,29 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -91,14 +109,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/remux-2160p-combined.yml
+++ b/radarr/templates/remux-2160p-combined.yml
@@ -7,7 +7,7 @@
 ################################################################################
 
 radarr:
-  remux-2160p-combined:
+  radarr-remux-2160p-combined:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -43,6 +43,7 @@ radarr:
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
@@ -58,12 +59,29 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -91,14 +109,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -7,7 +7,7 @@
 ################################################################################
 
 radarr:
-  remux-web-1080p:
+  radarr-remux-web-1080p:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -43,6 +43,7 @@ radarr:
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
@@ -61,6 +62,19 @@ radarr:
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -92,6 +106,7 @@ radarr:
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -7,7 +7,7 @@
 ################################################################################
 
 radarr:
-  remux-web-2160p:
+  radarr-remux-web-2160p:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -43,6 +43,7 @@ radarr:
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
@@ -58,12 +59,29 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -91,14 +109,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-1-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-1080p.yml
@@ -29,13 +29,17 @@ radarr:
       add:
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -77,6 +81,7 @@ radarr:
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -29,19 +29,27 @@ radarr:
       add:
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -75,14 +83,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-1-web-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-web-1080p.yml
@@ -29,13 +29,17 @@ radarr:
       add:
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -77,6 +81,7 @@ radarr:
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-1-web-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-web-2160p.yml
@@ -29,19 +29,27 @@ radarr:
       add:
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -75,14 +83,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -33,13 +33,17 @@ radarr:
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
@@ -47,6 +51,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -79,14 +87,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-3-audio.yml
+++ b/radarr/templates/sqp/sqp-3-audio.yml
@@ -33,13 +33,17 @@ radarr:
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
@@ -47,6 +51,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -79,14 +87,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -33,13 +33,17 @@ radarr:
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
@@ -47,6 +51,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -79,14 +87,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-4-ma-hybrid.yml
+++ b/radarr/templates/sqp/sqp-4-ma-hybrid.yml
@@ -33,17 +33,22 @@ radarr:
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
+        # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
@@ -91,6 +96,7 @@ radarr:
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -33,13 +33,17 @@ radarr:
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
@@ -47,6 +51,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -79,14 +87,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -33,13 +33,17 @@ radarr:
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
@@ -47,6 +51,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -79,14 +87,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -43,6 +43,7 @@ radarr:
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
@@ -58,12 +59,29 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -91,14 +109,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/sonarr/templates/anime-remux-1080p.yml
+++ b/sonarr/templates/anime-remux-1080p.yml
@@ -30,6 +30,7 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -56,27 +57,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/french-multi-vf-bluray-web-1080p.yml
+++ b/sonarr/templates/french-multi-vf-bluray-web-1080p.yml
@@ -34,7 +34,22 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          select:
+            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
+            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -61,27 +76,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/french-multi-vf-bluray-web-2160p.yml
+++ b/sonarr/templates/french-multi-vf-bluray-web-2160p.yml
@@ -34,14 +34,33 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          select:
+            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
+            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
@@ -64,31 +83,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/french-multi-vo-bluray-web-1080p.yml
+++ b/sonarr/templates/french-multi-vo-bluray-web-1080p.yml
@@ -34,7 +34,22 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          select:
+            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
+            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -61,27 +76,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/french-multi-vo-bluray-web-2160p.yml
+++ b/sonarr/templates/french-multi-vo-bluray-web-2160p.yml
@@ -34,14 +34,33 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          select:
+            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
+            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
@@ -64,31 +83,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/french-vostfr-bluray-web-1080p.yml
+++ b/sonarr/templates/french-vostfr-bluray-web-1080p.yml
@@ -34,7 +34,22 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          select:
+            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
+            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -61,27 +76,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/french-vostfr-bluray-web-2160p.yml
+++ b/sonarr/templates/french-vostfr-bluray-web-2160p.yml
@@ -34,14 +34,33 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          select:
+            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
+            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
@@ -64,31 +83,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/german-anime-hd-bluray-web.yml
+++ b/sonarr/templates/german-anime-hd-bluray-web.yml
@@ -27,21 +27,28 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+        - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          select:
+            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - a6a6c33d057406aaad978a6902823c35  # German LQ
+            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -68,27 +75,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/german-hd-bluray-web.yml
+++ b/sonarr/templates/german-hd-bluray-web.yml
@@ -34,21 +34,24 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - a6a6c33d057406aaad978a6902823c35  # German LQ
+            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -75,27 +78,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/german-hd-remux-web.yml
+++ b/sonarr/templates/german-hd-remux-web.yml
@@ -34,21 +34,24 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - a6a6c33d057406aaad978a6902823c35  # German LQ
+            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -75,27 +78,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/sonarr/templates/german-uhd-bluray-web-alternative.yml
@@ -30,36 +30,39 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
-          select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - a6a6c33d057406aaad978a6902823c35  # German LQ
+            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
@@ -82,31 +85,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/german-uhd-bluray-web.yml
+++ b/sonarr/templates/german-uhd-bluray-web.yml
@@ -30,36 +30,39 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
-          select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - a6a6c33d057406aaad978a6902823c35  # German LQ
+            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
@@ -82,31 +85,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/remux-2160p-alternative.yml
+++ b/sonarr/templates/remux-2160p-alternative.yml
@@ -1,13 +1,10 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Remux + WEB
-##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-
-## en/#uhd-remux-web-2160p
+## TRaSH Guides: Remux 2160p (Alternative)
 ################################################################################
 
 sonarr:
-  sonarr-german-uhd-remux-web:
+  sonarr-remux-2160p-alternative:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +12,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 08cececf1840290f6fd490b7d79e8642  # [German] UHD Remux + WEB
+      - trash_id: 361717d531db5a6002e0f547ace46551  # Remux 2160p (Alternative)
         reset_unmatched_scores:
           enabled: true
 
@@ -34,23 +31,38 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
+        - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
+          select:
+            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
-        # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
@@ -58,7 +70,10 @@ sonarr:
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
+        #   select:
+        #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
+        #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR

--- a/sonarr/templates/remux-2160p-combined.yml
+++ b/sonarr/templates/remux-2160p-combined.yml
@@ -1,13 +1,10 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Remux + WEB
-##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-
-## en/#uhd-remux-web-2160p
+## TRaSH Guides: Remux 2160p (Combined)
 ################################################################################
 
 sonarr:
-  sonarr-german-uhd-remux-web:
+  sonarr-remux-2160p-combined:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +12,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 08cececf1840290f6fd490b7d79e8642  # [German] UHD Remux + WEB
+      - trash_id: 911df0e05a395c19d8b3efc76a7467c1  # Remux 2160p (Combined)
         reset_unmatched_scores:
           enabled: true
 
@@ -34,23 +31,38 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
+        - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
+          select:
+            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
-        # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
@@ -58,7 +70,10 @@ sonarr:
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
+        #   select:
+        #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
+        #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR

--- a/sonarr/templates/remux-web-1080p.yml
+++ b/sonarr/templates/remux-web-1080p.yml
@@ -1,13 +1,10 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Remux + WEB
-##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-
-## en/#uhd-remux-web-2160p
+## TRaSH Guides: Remux + WEB 1080p
 ################################################################################
 
 sonarr:
-  sonarr-german-uhd-remux-web:
+  sonarr-remux-web-1080p:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +12,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 08cececf1840290f6fd490b7d79e8642  # [German] UHD Remux + WEB
+      - trash_id: fe9470e577c300a5ad9a3274f6d1cdf2  # Remux + WEB 1080p
         reset_unmatched_scores:
           enabled: true
 
@@ -30,39 +27,51 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+        - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
           select:
-            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
+        - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
+          select:
+            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
-        # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
-        # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
-        # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
         #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
+        #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
@@ -103,5 +112,4 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       skip:
-        # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/remux-web-2160p.yml
+++ b/sonarr/templates/remux-web-2160p.yml
@@ -1,13 +1,10 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Remux + WEB
-##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-
-## en/#uhd-remux-web-2160p
+## TRaSH Guides: Remux + WEB 2160p
 ################################################################################
 
 sonarr:
-  sonarr-german-uhd-remux-web:
+  sonarr-remux-web-2160p:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +12,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 08cececf1840290f6fd490b7d79e8642  # [German] UHD Remux + WEB
+      - trash_id: 76a5053bdb2d1e4a8f16a69a37d46c12  # Remux + WEB 2160p
         reset_unmatched_scores:
           enabled: true
 
@@ -34,23 +31,38 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
+        - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
+          select:
+            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
-        # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
@@ -58,7 +70,10 @@ sonarr:
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
+        #   select:
+        #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
+        #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR

--- a/sonarr/templates/web-1080p-alternative.yml
+++ b/sonarr/templates/web-1080p-alternative.yml
@@ -33,6 +33,19 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
           select:
             - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
@@ -42,7 +55,8 @@ sonarr:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
             - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
@@ -51,30 +65,22 @@ sonarr:
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
-        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
+        #   select:
+        #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
+        #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
         #     - c196536ea8122397c5854040d01f2aa7  # WiTH ASL
         #     - b40dc2e630723745aab9f1b94f4aab74  # WiTH BASL
         #     - 0aef382c4ed4c5eb5d40109dfd351b72  # WiTH BSL
-        # - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
-        #   select:
-        #     - 8a9fcdbb445f2add0505926df3bb7b8a  # German
-        #     - ed51973a811f51985f14e2f6f290e47a  # German DL
-        #     - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
-        #     - 21d4ae0976f7a4c251884d26fc46183c  # German Subbed
-        #     - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
-        #     - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-        #     - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
-        #     - 133589380b89f8f8394320901529bac1  # Not German or English
-        #     - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
-        #     - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
         # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         #   select:
         #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
@@ -91,27 +97,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/web-1080p.yml
+++ b/sonarr/templates/web-1080p.yml
@@ -33,6 +33,19 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
           select:
             - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
@@ -42,7 +55,8 @@ sonarr:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
             - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
@@ -52,6 +66,7 @@ sonarr:
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -62,18 +77,6 @@ sonarr:
         #     - c196536ea8122397c5854040d01f2aa7  # WiTH ASL
         #     - b40dc2e630723745aab9f1b94f4aab74  # WiTH BASL
         #     - 0aef382c4ed4c5eb5d40109dfd351b72  # WiTH BSL
-        # - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
-        #   select:
-        #     - 8a9fcdbb445f2add0505926df3bb7b8a  # German
-        #     - ed51973a811f51985f14e2f6f290e47a  # German DL
-        #     - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
-        #     - 21d4ae0976f7a4c251884d26fc46183c  # German Subbed
-        #     - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
-        #     - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-        #     - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
-        #     - 133589380b89f8f8394320901529bac1  # Not German or English
-        #     - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
-        #     - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
         # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         #   select:
         #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
@@ -90,27 +93,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/web-2160p-alternative.yml
+++ b/sonarr/templates/web-2160p-alternative.yml
@@ -33,6 +33,19 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
           select:
             - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
@@ -42,7 +55,8 @@ sonarr:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
             - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
@@ -51,33 +65,29 @@ sonarr:
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
-        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
+        #   select:
+        #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
+        #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
         #     - c196536ea8122397c5854040d01f2aa7  # WiTH ASL
         #     - b40dc2e630723745aab9f1b94f4aab74  # WiTH BASL
         #     - 0aef382c4ed4c5eb5d40109dfd351b72  # WiTH BSL
-        # - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
-        #   select:
-        #     - 8a9fcdbb445f2add0505926df3bb7b8a  # German
-        #     - ed51973a811f51985f14e2f6f290e47a  # German DL
-        #     - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
-        #     - 21d4ae0976f7a4c251884d26fc46183c  # German Subbed
-        #     - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
-        #     - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-        #     - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
-        #     - 133589380b89f8f8394320901529bac1  # Not German or English
-        #     - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
-        #     - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
         # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         #   select:
         #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
@@ -94,31 +104,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/web-2160p-combined.yml
+++ b/sonarr/templates/web-2160p-combined.yml
@@ -33,6 +33,19 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
           select:
             - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
@@ -42,7 +55,8 @@ sonarr:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
             - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
@@ -55,28 +69,21 @@ sonarr:
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
         #     - c196536ea8122397c5854040d01f2aa7  # WiTH ASL
         #     - b40dc2e630723745aab9f1b94f4aab74  # WiTH BASL
         #     - 0aef382c4ed4c5eb5d40109dfd351b72  # WiTH BSL
-        # - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
-        #   select:
-        #     - 8a9fcdbb445f2add0505926df3bb7b8a  # German
-        #     - ed51973a811f51985f14e2f6f290e47a  # German DL
-        #     - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
-        #     - 21d4ae0976f7a4c251884d26fc46183c  # German Subbed
-        #     - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
-        #     - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-        #     - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
-        #     - 133589380b89f8f8394320901529bac1  # Not German or English
-        #     - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
-        #     - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
         # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         #   select:
         #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
@@ -93,31 +100,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/web-2160p.yml
+++ b/sonarr/templates/web-2160p.yml
@@ -33,6 +33,19 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
           select:
             - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
@@ -42,7 +55,8 @@ sonarr:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
             - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
@@ -55,28 +69,21 @@ sonarr:
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
         #     - c196536ea8122397c5854040d01f2aa7  # WiTH ASL
         #     - b40dc2e630723745aab9f1b94f4aab74  # WiTH BASL
         #     - 0aef382c4ed4c5eb5d40109dfd351b72  # WiTH BSL
-        # - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
-        #   select:
-        #     - 8a9fcdbb445f2add0505926df3bb7b8a  # German
-        #     - ed51973a811f51985f14e2f6f290e47a  # German DL
-        #     - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
-        #     - 21d4ae0976f7a4c251884d26fc46183c  # German Subbed
-        #     - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
-        #     - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-        #     - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
-        #     - 133589380b89f8f8394320901529bac1  # Not German or English
-        #     - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
-        #     - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
         # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         #   select:
         #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
@@ -93,31 +100,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/templates.json
+++ b/templates.json
@@ -82,19 +82,19 @@
     },
     {
       "template": "radarr/templates/remux-2160p-alternative.yml",
-      "id": "remux-2160p-alternative"
+      "id": "radarr-remux-2160p-alternative"
     },
     {
       "template": "radarr/templates/remux-2160p-combined.yml",
-      "id": "remux-2160p-combined"
+      "id": "radarr-remux-2160p-combined"
     },
     {
       "template": "radarr/templates/remux-web-1080p.yml",
-      "id": "remux-web-1080p"
+      "id": "radarr-remux-web-1080p"
     },
     {
       "template": "radarr/templates/remux-web-2160p.yml",
-      "id": "remux-web-2160p"
+      "id": "radarr-remux-web-2160p"
     },
     {
       "template": "radarr/templates/sqp/sqp-1-1080p.yml",
@@ -193,6 +193,22 @@
     {
       "template": "sonarr/templates/german-uhd-remux-web.yml",
       "id": "sonarr-german-uhd-remux-web"
+    },
+    {
+      "template": "sonarr/templates/remux-2160p-alternative.yml",
+      "id": "sonarr-remux-2160p-alternative"
+    },
+    {
+      "template": "sonarr/templates/remux-2160p-combined.yml",
+      "id": "sonarr-remux-2160p-combined"
+    },
+    {
+      "template": "sonarr/templates/remux-web-1080p.yml",
+      "id": "sonarr-remux-web-1080p"
+    },
+    {
+      "template": "sonarr/templates/remux-web-2160p.yml",
+      "id": "sonarr-remux-web-2160p"
     },
     {
       "template": "sonarr/templates/web-1080p.yml",


### PR DESCRIPTION
## Summary

Regenerates all templates against current TRaSH-Guides JSONs. No generator changes; this is
upstream drift only.

- 53 templates updated (35 radarr, 18 sonarr)
- 4 new sonarr Remux templates for new upstream profiles (Remux + WEB 1080p/2160p, Remux 2160p
  Alternative/Combined)

## Breaking

The new sonarr Remux profiles share filenames with existing radarr profiles, so the cross-service
disambiguation rule now applies to both sides. Four radarr template IDs change:

| Old | New |
| --- | --- |
| `remux-2160p-alternative` | `radarr-remux-2160p-alternative` |
| `remux-2160p-combined` | `radarr-remux-2160p-combined` |
| `remux-web-1080p` | `radarr-remux-web-1080p` |
| `remux-web-2160p` | `radarr-remux-web-2160p` |

Only `recyclarr config create --template <id>` resolves these IDs, and it copies the file once
rather than resolving it on each sync, so existing configurations are unaffected. Run
`recyclarr config list templates` for the current IDs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four Sonarr remux profile templates for 1080p and 2160p configurations.
  * Added optional language, audio, HDR, and streaming-service selections across media profiles.
* **Enhancements**
  * Improved French, German, anime, and SQP profiles with more precise unwanted-format handling.
  * Added support for additional streaming-service selections, including CNLP, RED, and STRP.
  * Added language-profile options and Line/Mic Dubbed filtering where applicable.
* **Configuration**
  * Standardized Radarr and Sonarr template naming with consistent product prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->