### PR TITLE
fix: render CF group options against current Recyclarr semantics

### DIFF
--- a/.github/workflows/check-trash-ids.yml
+++ b/.github/workflows/check-trash-ids.yml
@@ -25,3 +25,6 @@ jobs:
 
       - name: Check Trash IDs
         run: pwsh ci/CheckInvalidTrashIds.ps1 trash .
+
+      - name: Check Conflicting Custom Formats
+        run: python3 ci/check_conflicting_cfs.py trash .

--- a/ci/check_conflicting_cfs.py
+++ b/ci/check_conflicting_cfs.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Assert no template can enable two mutually exclusive custom formats.
+
+Usage: check_conflicting_cfs.py <path-to-trash-guides> <path-to-config-repo>
+
+The TRaSH Guides publish conflicts.json, naming sets of custom formats that
+must not be enabled together. Recyclarr does not read that file, so these
+checks live here instead.
+
+Pass A: each template's effective CF set holds at most one member of any
+        conflict set, where the effective set is
+        required + (default - exclude) + select.
+Pass B: within a commented-out group block, at most one member of a conflict
+        set sits at the block's own comment level, so uncommenting the block
+        cannot activate several at once.
+
+Both are assertions about the committed text. Neither simulates what a user
+might do after editing a template.
+"""
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+GUIDES = Path(sys.argv[1])
+REPO = Path(sys.argv[2])
+
+_spec = importlib.util.spec_from_file_location(
+    "gen", REPO / "scripts" / "generate-template.py"
+)
+gen = importlib.util.module_from_spec(_spec)
+# Register before exec: @dataclass resolves cls.__module__ via sys.modules.
+sys.modules["gen"] = gen
+_spec.loader.exec_module(gen)
+
+GROUP_RE = re.compile(r"^(?P<pre>[^-]*)- trash_id:\s*(?P<id>[a-f0-9]{32})")
+NODE_RE = re.compile(r"^(?P<pre>[^a-z]*)(?P<node>select|exclude):\s*$")
+BARE_RE = re.compile(r"^(?P<pre>[^-]*)-\s*(?P<id>[a-f0-9]{32})")
+PROFILE_RE = re.compile(r"^\s*- trash_id:\s*([a-f0-9]{32})\s*#")
+
+exit_code = 0
+
+
+def error(file: Path, line: int, message: str) -> None:
+    global exit_code
+    rel = file.relative_to(REPO).as_posix()
+    print(f"::error file={rel},line={line},title=Conflicting Custom Formats::{message}")
+    exit_code = 1
+
+
+def depth(pre: str) -> int:
+    """How many comment markers precede the list dash."""
+    return pre.count("#")
+
+
+def check_service(service: str) -> None:
+    json_paths = gen.load_guides(GUIDES)
+    conflict_sets = gen.load_conflicts(GUIDES, json_paths, service)
+    if not conflict_sets:
+        print(
+            "::warning title=Conflicting Custom Formats::"
+            f"No conflict sets found for {service}; nothing to check"
+        )
+        return
+
+    cf_groups = gen.load_cf_groups(GUIDES, json_paths, service)
+    names = {
+        cf.trash_id: cf.name for g in cf_groups.values() for cf in g.custom_formats
+    }
+
+    for path in sorted((REPO / service / "templates").rglob("*.yml")):
+        print(f"Processing {path}")
+        lines = path.read_text(encoding="utf-8").splitlines()
+
+        profile_id = None
+        section = None
+        group_id = None
+        group_depth = 0
+        node = None
+        adds: dict[str, dict] = {}
+        skips: set[str] = set()
+        # group id -> [(line number, cf id)] for select members at block depth
+        base_level: dict[str, list[tuple[int, str]]] = {}
+
+        for i, raw in enumerate(lines, start=1):
+            stripped = raw.strip()
+
+            if stripped.startswith("quality_profiles:"):
+                section, group_id, node = "profiles", None, None
+                continue
+            if stripped in ("add:", "# add:"):
+                section, group_id, node = "add", None, None
+                continue
+            if stripped in ("skip:", "# skip:"):
+                section, group_id, node = "skip", None, None
+                continue
+            if stripped.startswith("custom_format_groups:"):
+                section, group_id, node = None, None, None
+                continue
+
+            if section == "profiles" and profile_id is None:
+                m = PROFILE_RE.match(raw)
+                if m:
+                    profile_id = m.group(1)
+                continue
+
+            if section == "add":
+                m = GROUP_RE.match(raw)
+                if m:
+                    group_id = m.group("id")
+                    group_depth = depth(m.group("pre"))
+                    adds[group_id] = {
+                        "active": group_depth == 0,
+                        "select": set(),
+                        "exclude": set(),
+                    }
+                    base_level[group_id] = []
+                    node = None
+                    continue
+                m = NODE_RE.match(raw)
+                if m and group_id:
+                    node = m.group("node")
+                    continue
+                m = BARE_RE.match(raw)
+                if m and group_id and node:
+                    d = depth(m.group("pre"))
+                    if d == 0:
+                        adds[group_id][node].add(m.group("id"))
+                    if node == "select" and d == group_depth and group_depth > 0:
+                        base_level[group_id].append((i, m.group("id")))
+                continue
+
+            if section == "skip":
+                m = BARE_RE.match(raw)
+                if m and depth(m.group("pre")) == 0:
+                    skips.add(m.group("id"))
+                continue
+
+        if profile_id is None:
+            error(path, 1, "No quality profile trash_id found")
+            continue
+
+        # Pass A: what this template actually syncs
+        effective: set[str] = set()
+        for group in cf_groups.values():
+            if profile_id not in group.target_profiles.values():
+                continue
+            if group.trash_id in skips:
+                continue
+            entry = adds.get(group.trash_id)
+            enabled = group.is_default or (entry is not None and entry["active"])
+            if not enabled:
+                continue
+            base = {c.trash_id for c in group.custom_formats if c.required or c.default}
+            if entry is not None:
+                base = (base - entry["exclude"]) | entry["select"]
+            effective |= base
+
+        for cs in conflict_sets:
+            clash = sorted(effective & cs)
+            if len(clash) > 1:
+                labels = ", ".join(f"{names.get(t, t)} ({t})" for t in clash)
+                error(
+                    path,
+                    1,
+                    f"Effective CF set enables conflicting formats: {labels}",
+                )
+
+        # Pass B: what one uncomment of a commented block would activate
+        for gid, entries in base_level.items():
+            for cs in conflict_sets:
+                clash = [(ln, t) for ln, t in entries if t in cs]
+                if len(clash) > 1:
+                    labels = ", ".join(f"{names.get(t, t)} ({t})" for _, t in clash)
+                    gname = cf_groups[gid].name if gid in cf_groups else gid
+                    error(
+                        path,
+                        clash[1][0],
+                        f"Group '{gname}': uncommenting this block would enable "
+                        f"conflicting formats: {labels}",
+                    )
+
+
+for svc in gen.SERVICES:
+    check_service(svc)
+
+sys.exit(exit_code)

--- a/radarr/templates/anime-remux-1080p.yml
+++ b/radarr/templates/anime-remux-1080p.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).

--- a/radarr/templates/anime-remux-1080p.yml
+++ b/radarr/templates/anime-remux-1080p.yml
@@ -39,6 +39,19 @@ radarr:
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -57,6 +70,7 @@ radarr:
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vf-hd-bluray-web.yml
+++ b/radarr/templates/french-multi-vf-hd-bluray-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,22 +88,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vf-hd-bluray-web.yml
+++ b/radarr/templates/french-multi-vf-hd-bluray-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,26 +36,28 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          exclude:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:
-            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch

--- a/radarr/templates/french-multi-vf-hd-bluray-web.yml
+++ b/radarr/templates/french-multi-vf-hd-bluray-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:

--- a/radarr/templates/french-multi-vf-hd-remux-web.yml
+++ b/radarr/templates/french-multi-vf-hd-remux-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,22 +88,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vf-hd-remux-web.yml
+++ b/radarr/templates/french-multi-vf-hd-remux-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,26 +36,28 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          exclude:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:
-            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch

--- a/radarr/templates/french-multi-vf-hd-remux-web.yml
+++ b/radarr/templates/french-multi-vf-hd-remux-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:

--- a/radarr/templates/french-multi-vf-uhd-bluray-web.yml
+++ b/radarr/templates/french-multi-vf-uhd-bluray-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -66,9 +67,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/french-multi-vf-uhd-bluray-web.yml
+++ b/radarr/templates/french-multi-vf-uhd-bluray-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,26 +36,28 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/french-multi-vf-uhd-bluray-web.yml
+++ b/radarr/templates/french-multi-vf-uhd-bluray-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -41,6 +58,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -74,26 +95,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vf-uhd-remux-web.yml
+++ b/radarr/templates/french-multi-vf-uhd-remux-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -66,9 +67,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/french-multi-vf-uhd-remux-web.yml
+++ b/radarr/templates/french-multi-vf-uhd-remux-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,26 +36,28 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/french-multi-vf-uhd-remux-web.yml
+++ b/radarr/templates/french-multi-vf-uhd-remux-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -41,6 +58,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -74,26 +95,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vo-hd-bluray-web.yml
+++ b/radarr/templates/french-multi-vo-hd-bluray-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,22 +88,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vo-hd-bluray-web.yml
+++ b/radarr/templates/french-multi-vo-hd-bluray-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,26 +36,28 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          exclude:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:
-            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch

--- a/radarr/templates/french-multi-vo-hd-bluray-web.yml
+++ b/radarr/templates/french-multi-vo-hd-bluray-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:

--- a/radarr/templates/french-multi-vo-hd-remux-web.yml
+++ b/radarr/templates/french-multi-vo-hd-remux-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,22 +88,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vo-hd-remux-web.yml
+++ b/radarr/templates/french-multi-vo-hd-remux-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,26 +36,28 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          exclude:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:
-            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch

--- a/radarr/templates/french-multi-vo-hd-remux-web.yml
+++ b/radarr/templates/french-multi-vo-hd-remux-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:

--- a/radarr/templates/french-multi-vo-uhd-bluray-web.yml
+++ b/radarr/templates/french-multi-vo-uhd-bluray-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -66,9 +67,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/french-multi-vo-uhd-bluray-web.yml
+++ b/radarr/templates/french-multi-vo-uhd-bluray-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,26 +36,28 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/french-multi-vo-uhd-bluray-web.yml
+++ b/radarr/templates/french-multi-vo-uhd-bluray-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -41,6 +58,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -74,26 +95,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-multi-vo-uhd-remux-web.yml
+++ b/radarr/templates/french-multi-vo-uhd-remux-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -66,9 +67,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/french-multi-vo-uhd-remux-web.yml
+++ b/radarr/templates/french-multi-vo-uhd-remux-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,26 +36,28 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/french-multi-vo-uhd-remux-web.yml
+++ b/radarr/templates/french-multi-vo-uhd-remux-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -41,6 +58,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -74,26 +95,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-vostfr-hd-bluray-web.yml
+++ b/radarr/templates/french-vostfr-hd-bluray-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,22 +88,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-vostfr-hd-bluray-web.yml
+++ b/radarr/templates/french-vostfr-hd-bluray-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,26 +36,28 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          exclude:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:
-            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch

--- a/radarr/templates/french-vostfr-hd-bluray-web.yml
+++ b/radarr/templates/french-vostfr-hd-bluray-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:

--- a/radarr/templates/french-vostfr-hd-remux-web.yml
+++ b/radarr/templates/french-vostfr-hd-remux-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -71,22 +88,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-vostfr-hd-remux-web.yml
+++ b/radarr/templates/french-vostfr-hd-remux-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,26 +36,28 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          exclude:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:
-            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch

--- a/radarr/templates/french-vostfr-hd-remux-web.yml
+++ b/radarr/templates/french-vostfr-hd-remux-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:

--- a/radarr/templates/french-vostfr-uhd-bluray-web.yml
+++ b/radarr/templates/french-vostfr-uhd-bluray-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -66,9 +67,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/french-vostfr-uhd-bluray-web.yml
+++ b/radarr/templates/french-vostfr-uhd-bluray-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,26 +36,28 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/french-vostfr-uhd-bluray-web.yml
+++ b/radarr/templates/french-vostfr-uhd-bluray-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -41,6 +58,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -74,26 +95,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/french-vostfr-uhd-remux-web.yml
+++ b/radarr/templates/french-vostfr-uhd-remux-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -66,9 +67,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/french-vostfr-uhd-remux-web.yml
+++ b/radarr/templates/french-vostfr-uhd-remux-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,26 +36,28 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/french-vostfr-uhd-remux-web.yml
+++ b/radarr/templates/french-vostfr-uhd-remux-web.yml
@@ -34,6 +34,23 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+        - trash_id: 59f7ab9ff64d0026b011b985b1cc8670  # [Unwanted] Unwanted Formats French
+          select:
+            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            - cae4ca30163749b891686f95532519bd  # AV1
+            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            - 0a3f082873eb454bde444150b70253cc  # Extras
+            - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
+            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+            # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+            # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
@@ -41,6 +58,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -74,26 +95,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: 12a919c8a5e2342db6e9c0b4e3c0756e  # [Release Groups] French
-        #   select:
-        #     - 5583260016e0b9f683f53af41fb42e4a  # FR Remux Tier 01
-        #     - 9019d81307e68cd4a7eb06a567e833b8  # FR Remux Tier 02
-        #     - 64f8f12bbf7472a6ccf838bfd6b5e3e8  # FR UHD Bluray Tier 01
-        #     - 0dcf0c8a386d82e3f2d424189af14065  # FR UHD Bluray Tier 02
-        #     - 5322da05b19d857acc1e75be3edf47b3  # FR HD Bluray Tier 01
-        #     - 57f34251344be2e283fc30e00e458be6  # FR HD Bluray Tier 02
-        #     - 9790a618cec1aeac8ce75601a17ea40d  # FR WEB Tier 01
-        #     - 3c83a765f84239716bd5fd2d7af188f9  # FR WEB Tier 02
-        #     - 0d94489c0d5828cd3bf9409d309fb32b  # FR Scene Groups
-        #     - 48f031e76111f17ea94898f4cdc34fdc  # FR LQ
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/german-anime-hd-bluray-web.yml
+++ b/radarr/templates/german-anime-hd-bluray-web.yml
@@ -27,23 +27,25 @@ radarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+        - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
           select:
             - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
             - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            # - f537cf427b64c38c8e36298f657e4828  # Scene
             - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
+        # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -71,14 +73,3 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene

--- a/radarr/templates/german-anime-hd-bluray-web.yml
+++ b/radarr/templates/german-anime-hd-bluray-web.yml
@@ -18,8 +18,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,23 +33,24 @@ radarr:
       ################################################################################
       add:
         - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            # - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            # - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
-            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
-            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,27 +36,29 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          exclude:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:
-            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            # - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            # - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
-            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
-            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -34,21 +34,22 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+        - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
           select:
             - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
             - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            # - f537cf427b64c38c8e36298f657e4828  # Scene
             - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
@@ -88,21 +89,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/german-hd-bluray-web.yml
+++ b/radarr/templates/german-hd-bluray-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:

--- a/radarr/templates/german-hd-remux-web.yml
+++ b/radarr/templates/german-hd-remux-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,27 +36,29 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          exclude:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:
-            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            # - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            # - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
-            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
-            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch

--- a/radarr/templates/german-hd-remux-web.yml
+++ b/radarr/templates/german-hd-remux-web.yml
@@ -34,21 +34,22 @@ radarr:
           select:
             - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+        - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
           select:
             - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
             - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            # - f537cf427b64c38c8e36298f657e4828  # Scene
             - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
@@ -88,21 +89,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/german-hd-remux-web.yml
+++ b/radarr/templates/german-hd-remux-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:

--- a/radarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/radarr/templates/german-uhd-bluray-web-alternative.yml
@@ -34,21 +34,22 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+        - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
           select:
             - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
             - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            # - f537cf427b64c38c8e36298f657e4828  # Scene
             - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
@@ -58,6 +59,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -91,25 +96,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/radarr/templates/german-uhd-bluray-web-alternative.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,27 +36,29 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            # - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            # - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
-            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
-            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/radarr/templates/german-uhd-bluray-web-alternative.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -67,9 +68,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -34,21 +34,22 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+        - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
           select:
             - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
             - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            # - f537cf427b64c38c8e36298f657e4828  # Scene
             - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
@@ -58,6 +59,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -91,25 +96,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,27 +36,29 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            # - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            # - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
-            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
-            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/german-uhd-bluray-web.yml
+++ b/radarr/templates/german-uhd-bluray-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -67,9 +68,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -34,21 +34,22 @@ radarr:
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
-        - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+        - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
           select:
             - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
             - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            # - f537cf427b64c38c8e36298f657e4828  # Scene
             - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
@@ -58,6 +59,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -91,25 +96,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
-        # - trash_id: bc85e56ee3bd0f01467866d5f1261543  # [Release Groups] German
-        #   select:
-        #     - 8608a2ed20c636b8a62de108e9147713  # German Remux Tier 01
-        #     - f9cf598d55ce532d63596b060a6db9ee  # German Remux Tier 02
-        #     - 54795711b78ea87e56127928c423689b  # German Bluray Tier 01
-        #     - 1bfc773c53283d47c68e535811da30b7  # German Bluray Tier 02
-        #     - aee01d40cd1bf4bcded81ee62f0f3659  # German Bluray Tier 03
-        #     - a2ab25194f463f057a5559c03c84a3df  # German Web Tier 01
-        #     - 08d120d5a003ec4954b5b255c0691d79  # German Web Tier 02
-        #     - 439f9d71becaed589058ec949e037ff3  # German Web Tier 03
-        #     - 2d136d4e33082fe573d06b1f237c40dd  # German Scene
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,27 +36,29 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 0ca61b4b233178d07113082a7acff72d  # [Unwanted] Unwanted Formats German
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
+            # - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
+            # - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - 263943bc5d99550c68aad0c4278ba1c7  # German LQ
-            - a826ee9e46607bc61795c85a6f2b1279  # German LQ (release title)
-            - 03c430f326f10a27a9739b8bc83c30e4  # German Microsized
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/german-uhd-remux-web.yml
+++ b/radarr/templates/german-uhd-remux-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -67,9 +68,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -20,8 +20,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -30,27 +35,29 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          exclude:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:
-            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -42,6 +42,7 @@ radarr:
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
@@ -60,6 +61,19 @@ radarr:
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -91,6 +105,7 @@ radarr:
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/hd-bluray-web.yml
+++ b/radarr/templates/hd-bluray-web.yml
@@ -35,6 +35,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:

--- a/radarr/templates/remux-2160p-alternative.yml
+++ b/radarr/templates/remux-2160p-alternative.yml
@@ -7,7 +7,7 @@
 ################################################################################
 
 radarr:
-  remux-2160p-alternative:
+  radarr-remux-2160p-alternative:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -43,6 +43,7 @@ radarr:
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
@@ -58,12 +59,29 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -91,14 +109,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/remux-2160p-alternative.yml
+++ b/radarr/templates/remux-2160p-alternative.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,27 +36,29 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/remux-2160p-alternative.yml
+++ b/radarr/templates/remux-2160p-alternative.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -67,9 +68,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/remux-2160p-combined.yml
+++ b/radarr/templates/remux-2160p-combined.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,27 +36,29 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/remux-2160p-combined.yml
+++ b/radarr/templates/remux-2160p-combined.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -67,9 +68,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/remux-2160p-combined.yml
+++ b/radarr/templates/remux-2160p-combined.yml
@@ -7,7 +7,7 @@
 ################################################################################
 
 radarr:
-  remux-2160p-combined:
+  radarr-remux-2160p-combined:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -43,6 +43,7 @@ radarr:
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
@@ -58,12 +59,29 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -91,14 +109,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,27 +36,29 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          exclude:
+            # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:
-            - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: f993ad37540147e4d00e66503545d81b  # [Streaming Services] Anime
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: f8bf8eab4617f12dfdbd16303d8da245  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           select:

--- a/radarr/templates/remux-web-1080p.yml
+++ b/radarr/templates/remux-web-1080p.yml
@@ -7,7 +7,7 @@
 ################################################################################
 
 radarr:
-  remux-web-1080p:
+  radarr-remux-web-1080p:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -43,6 +43,7 @@ radarr:
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
@@ -61,6 +62,19 @@ radarr:
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -92,6 +106,7 @@ radarr:
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,27 +36,29 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -67,9 +68,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/remux-web-2160p.yml
+++ b/radarr/templates/remux-web-2160p.yml
@@ -7,7 +7,7 @@
 ################################################################################
 
 radarr:
-  remux-web-2160p:
+  radarr-remux-web-2160p:
     base_url: Put your Radarr URL here
     api_key: Put your API key here
 
@@ -43,6 +43,7 @@ radarr:
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
@@ -58,12 +59,29 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -91,14 +109,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-1-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-1080p.yml
@@ -18,8 +18,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,19 +33,20 @@ radarr:
       ################################################################################
       add:
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
+          exclude:
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
             # - a5d148168c4506b55cf53984107c396e  # 10bit
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK

--- a/radarr/templates/sqp/sqp-1-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-1080p.yml
@@ -29,13 +29,17 @@ radarr:
       add:
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -77,6 +81,7 @@ radarr:
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -29,19 +29,27 @@ radarr:
       add:
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -75,14 +83,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -53,9 +53,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/sqp/sqp-1-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-2160p.yml
@@ -18,8 +18,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,19 +33,20 @@ radarr:
       ################################################################################
       add:
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
+          exclude:
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
             # - a5d148168c4506b55cf53984107c396e  # 10bit
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian

--- a/radarr/templates/sqp/sqp-1-web-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-web-1080p.yml
@@ -18,8 +18,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,19 +33,20 @@ radarr:
       ################################################################################
       add:
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
+          exclude:
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
             # - a5d148168c4506b55cf53984107c396e  # 10bit
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK

--- a/radarr/templates/sqp/sqp-1-web-1080p.yml
+++ b/radarr/templates/sqp/sqp-1-web-1080p.yml
@@ -29,13 +29,17 @@ radarr:
       add:
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
@@ -77,6 +81,7 @@ radarr:
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-1-web-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-web-2160p.yml
@@ -29,19 +29,27 @@ radarr:
       add:
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -75,14 +83,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-1-web-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-web-2160p.yml
@@ -53,9 +53,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/sqp/sqp-1-web-2160p.yml
+++ b/radarr/templates/sqp/sqp-1-web-2160p.yml
@@ -18,8 +18,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,19 +33,20 @@ radarr:
       ################################################################################
       add:
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
+          exclude:
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
             # - a5d148168c4506b55cf53984107c396e  # 10bit
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -18,8 +18,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,23 +33,25 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
+          exclude:
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
             # - a5d148168c4506b55cf53984107c396e  # 10bit
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -33,6 +33,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -59,9 +60,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/sqp/sqp-2.yml
+++ b/radarr/templates/sqp/sqp-2.yml
@@ -33,13 +33,17 @@ radarr:
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
@@ -47,6 +51,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -79,14 +87,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-3-audio.yml
+++ b/radarr/templates/sqp/sqp-3-audio.yml
@@ -18,8 +18,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,23 +33,25 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
+          exclude:
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
             # - a5d148168c4506b55cf53984107c396e  # 10bit
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/sqp/sqp-3-audio.yml
+++ b/radarr/templates/sqp/sqp-3-audio.yml
@@ -33,6 +33,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -59,9 +60,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/sqp/sqp-3-audio.yml
+++ b/radarr/templates/sqp/sqp-3-audio.yml
@@ -33,13 +33,17 @@ radarr:
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
@@ -47,6 +51,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -79,14 +87,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -18,8 +18,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,23 +33,25 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
+          exclude:
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
             # - a5d148168c4506b55cf53984107c396e  # 10bit
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -33,6 +33,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -59,9 +60,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/sqp/sqp-3.yml
+++ b/radarr/templates/sqp/sqp-3.yml
@@ -33,13 +33,17 @@ radarr:
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
@@ -47,6 +51,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -79,14 +87,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-4-ma-hybrid.yml
+++ b/radarr/templates/sqp/sqp-4-ma-hybrid.yml
@@ -18,8 +18,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,23 +33,25 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
+          exclude:
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
             # - a5d148168c4506b55cf53984107c396e  # 10bit
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/sqp/sqp-4-ma-hybrid.yml
+++ b/radarr/templates/sqp/sqp-4-ma-hybrid.yml
@@ -33,17 +33,22 @@ radarr:
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost
+        # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
@@ -91,6 +96,7 @@ radarr:
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-4-ma-hybrid.yml
+++ b/radarr/templates/sqp/sqp-4-ma-hybrid.yml
@@ -33,6 +33,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -18,8 +18,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,23 +33,25 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
+          exclude:
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
             # - a5d148168c4506b55cf53984107c396e  # 10bit
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -33,6 +33,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -59,9 +60,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/sqp/sqp-4.yml
+++ b/radarr/templates/sqp/sqp-4.yml
@@ -33,13 +33,17 @@ radarr:
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
@@ -47,6 +51,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -79,14 +87,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -18,8 +18,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,23 +33,25 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
+          exclude:
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
             # - a5d148168c4506b55cf53984107c396e  # 10bit
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -33,6 +33,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -59,9 +60,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/radarr/templates/sqp/sqp-5.yml
+++ b/radarr/templates/sqp/sqp-5.yml
@@ -33,13 +33,17 @@ radarr:
             - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: 15b1cf0b6f1a1493856a4355907affee  # [Unwanted] Unwanted Formats SQP
           select:
+            # - a5d148168c4506b55cf53984107c396e  # 10bit
             - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
             - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
+            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
             - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
@@ -47,6 +51,10 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
@@ -79,14 +87,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -43,6 +43,7 @@ radarr:
             - ed38b889b31be83fda192888e2286d83  # BR-DISK
             - 0a3f082873eb454bde444150b70253cc  # Extras
             - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
             - 90a6f9a284dff5103f6346090e6280c8  # LQ
             - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
@@ -58,12 +59,29 @@ radarr:
         # - trash_id: b22449f789b16a4163b59f1b70cbc580  # [Streaming Services] Asian
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
+        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   select:
+        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
+        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD
         #     - 09c60ba54fadb511c6986a7edec4da4b  # WiTH ASL
         #     - 41e4baea7b10ddefc6609d52f742dacd  # WiTH BASL
         #     - e205c5ba6be76b472903f4aec97fdb4b  # WiTH BSL
+        # - trash_id: 13856622cf7a6c9925d3a83f8812d679  # [Optional] Language Profiles
+        #   select:
+        #     - 86bc3115eb4e9873ac96904a4a68e19e  # German
+        #     - f845be10da4f442654c13e1f2c3d6cd5  # German DL
+        #     - 6aad77771dabe9d3e9d7be86f310b867  # German DL (undefined)
+        #     - 0dc8aec3bd1c47cd6c40c46ecd27e846  # Language: Not English
+        #     - 533f782474f0819643c2ec0c1eeeb0ac  # Language: Not French
+        #     - d6e9318c875905d6cfb5bee961afcea9  # Language: Not Original
+        #     - 0542a48746585dc4444bbbb8a6bdf6ea  # Language: Original + French
+        #     - 4eadb75fb23d09dfc0a8e3f687e72287  # Not German or English
+        #     - 532c4a41c94ae0f77c745ae478883c44  # Not German, Japanese or English
+        #     - 9a8f58fae5df94783c214c0ed63f589c  # Not German, Japanese, Korean, Chinese or English
+        #     - 2051402ee9ca81162017d98cbe1dff2c  # Wrong Language
         # - trash_id: 9337080378236ce4c0b183e35790d2a7  # [Optional] Miscellaneous
         #   select:
         #     - f700d29429c023a5734505e77daeaea7  # DV (Disk)
@@ -91,14 +109,11 @@ radarr:
         #     - 957d0f44b592285f26449575e8b1167e  # Special Edition
         #     - e9001909a4c88013a359d0b9920d7bea  # Theatrical Cut
         #     - db9b4c4b53d312a3ca5f1378f6440fc9  # Vinegar Syndrome
-        # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [Optional] SDR
-        #   select:
-        #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: 9fc645b3cef52b149ec13ba3972245d1  # [Streaming Services] Miscellaneous
         #   select:
         #     - 3bf143ecd06f66ed88da4c704350af1d  # AUBC
         #     - d9058beaae2e147183870304dd526761  # CBC
+        #     - 1f9dfb4b8d9cae1f6dc0099547d53513  # CNLP
         #     - f6ff65b3f4b464a79dcc75950fe20382  # CRAV
         #     - fbca986396c5e695ef7b2def3c755d01  # OViD
         #     - ab56ccdc473a1f2897c76187ea365be2  # STRP

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -21,8 +21,13 @@ radarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,27 +36,29 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          exclude:
+            # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
             # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-            - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
         - trash_id: a3ac6af01d78e4f21fcb75f601ac96df  # [Unwanted] Unwanted Formats
+          exclude:
+            # - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+            # - cae4ca30163749b891686f95532519bd  # AV1
+            # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+            # - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
+            # - ed38b889b31be83fda192888e2286d83  # BR-DISK
+            # - 0a3f082873eb454bde444150b70253cc  # Extras
+            # - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
+            # - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
+            # - 90a6f9a284dff5103f6346090e6280c8  # LQ
+            # - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
+            # - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
+            # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           select:
-            - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
-            - cae4ca30163749b891686f95532519bd  # AV1
-            - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
-            - cc444569854e9de0b084ab2b8b1532b2  # Black and White Editions
-            - ed38b889b31be83fda192888e2286d83  # BR-DISK
-            - 0a3f082873eb454bde444150b70253cc  # Extras
-            - e6886871085226c3da1830830146846c  # Generated Dynamic HDR
-            - c465ccc73923871b3eb1802042331306  # Line/Mic Dubbed
-            - 90a6f9a284dff5103f6346090e6280c8  # LQ
-            - e204b80c87be9497a8a6eaff48f72905  # LQ (Release Title)
             # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
             # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
             # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
             # - f537cf427b64c38c8e36298f657e4828  # Scene
-            - 712d74cd88bceb883ee32f773656b1f5  # Sing-Along Versions
-            - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
         # - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: 1616617ab3a14397a2b2321bcbda44d1  # [HDR Formats] DV Boost
         # - trash_id: b29413a7487478fe98228ce79e5689e4  # [HDR Formats] HDR10+ Boost

--- a/radarr/templates/uhd-bluray-web.yml
+++ b/radarr/templates/uhd-bluray-web.yml
@@ -36,6 +36,7 @@ radarr:
       ################################################################################
       add:
         - trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
           select:
@@ -67,9 +68,10 @@ radarr:
         # - trash_id: 088a792e0561c927fb396664b0db5c8f  # [Streaming Services] Dutch
         # - trash_id: f737e18b5824d6ebb2d57b957ae2fd6c  # [Streaming Services] UK
         # - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 9c38ebb7384dada637be8899efa68e6f  # SDR
-        #     - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
+        #     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
         # - trash_id: bc3c13e52f2971319bc1748ffa3d1078  # [Optional] Accessibility
         #   select:
         #     - 127bdbadcf3e4463a8c707759fbaad75  # WiTH AD

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,8 +21,8 @@ custom_format_groups:
     # - trash_id: abc123  # [Optional] Some Group
 ```
 
-If the group contains CFs that are neither `required` nor `default` (i.e. the user must choose which
-to include), a `select:` block is added showing those CFs:
+If the group has CFs the user can toggle, they are listed beneath it. See "CF rendering within a
+group" below.
 
 ```yaml
 custom_format_groups:
@@ -45,47 +45,64 @@ custom_format_groups:
     # - abc123  # [Required] Some Group
 ```
 
-### Default groups with user choices
+### Default groups with adjustable CFs
 
-Groups that are enabled by default but contain mutually exclusive CFs where the user is expected to
-choose one. Detected when a `default: true` group has at least one CF with `default: true` at the CF
-level.
-
-These are rendered under `add:`, **uncommented**, with an explicit `select:` block. CFs marked
-`default: true` are uncommented (active); others are commented out (available as alternatives).
+Groups where `default` is `true` at the group level and at least one CF within the group defines
+`default: true`. Recyclarr syncs these whether or not they appear in the YAML, so they are rendered
+under `add:`, uncommented, to make their CFs adjustable.
 
 ```yaml
 custom_format_groups:
   add:
-    - trash_id: abc123  # [Required] Golden Rule HD
+    - trash_id: abc123  # [Optional] Golden Rule UHD
+      exclude:
+        # - def456  # x265 (no HDR/DV)
       select:
-        - def456  # x265 (HD)
-        # - ghi789  # x265 (no HDR/DV)
+        # - ghi789  # x265 (HD)
 ```
 
-This rendering differs from how Recyclarr would handle the group implicitly (it would just apply the
-`default: true` CF without user intervention). The template deliberately surfaces the choice so
-users can see and swap between alternatives. The template is a presentation layer; it does not need
-to mirror Recyclarr's runtime behavior.
+## CF rendering within a group
 
-Currently only the four Golden Rule groups (HD and UHD, for both Radarr and Sonarr) match this
-pattern.
+One rule covers every group under `add:`, matching Recyclarr 8.1.0+ semantics where the effective
+set is `required + (default - exclude) + select`:
 
-## Design Decisions
+| CF flag | Rendered as |
+| --- | --- |
+| `required` | not listed; always included and cannot be excluded |
+| `default` | commented under `exclude:`; uncomment to turn OFF |
+| neither | commented under `select:`; uncomment to turn ON |
 
-### Template rendering is a presentation concern, not a runtime one (2026-02-28)
+A node with no members is omitted. In an uncommented group the `exclude:` and `select:` keys
+themselves stay uncommented, so toggling a CF is one uncomment rather than two. An empty node is
+valid: Recyclarr's schema types both as `["null", "array"]` and maps null to an empty list.
 
-Recyclarr automatically applies default CF groups and their `default: true` CFs without any YAML
-configuration. The template generation script does not need to mirror that behavior. Its job is to
-present all meaningful user choices explicitly, even when the defaults would produce the correct
-result without intervention.
+Inside a commented (opt-in) group the whole block is commented, so `exclude:` members carry an extra
+comment level. Otherwise enabling the group would also strip its defaults.
 
-This distinction matters for groups like Golden Rule, where two mutually exclusive CFs exist and the
-user is expected to pick one. Recyclarr silently applies the `default: true` CF; a user editing YAML
-by hand would never know the alternative exists. The script renders these as explicit `add:` entries
-with `select:` blocks so the choice is visible. The guide data's `default: true` at the CF level is
-the detection signal for this; no other groups currently use it.
+## Conflicting custom formats
 
-This was a deliberate decision over the simpler approach of putting all `default: true` groups under
-`skip:` uniformly. The trade-off is that the script now has three rendering paths instead of two,
-but the added complexity is justified by the user-facing clarity it provides.
+The guides publish `conflicts.json`, naming sets of CFs that must not be enabled together. Recyclarr
+does not read this file, so the templates handle it themselves. It is loaded via `metadata.json`
+`json_paths.<service>.conflicts` so new sets are picked up without a code change, and it affects
+rendering in two ways.
+
+Groups holding two or more members of one set gain a note:
+
+```yaml
+- trash_id: abc123  # [Optional] Golden Rule UHD
+  # Mutually exclusive: enable only one of the following.
+```
+
+And in a commented group whose conflicting members all sit under `select:`, one member stays at the
+block's own comment level while the rest are nested one level deeper, so uncommenting the block
+enables exactly one:
+
+```yaml
+# - trash_id: abc123  # [HDR Formats] SDR
+#   # Mutually exclusive: enable only one of the following.
+#   select:
+#     - def456  # SDR
+#     # - ghi789  # SDR (no WEBDL)
+```
+
+`ci/check_conflicting_cfs.py` asserts both properties over the committed templates.

--- a/scripts/generate-template.py
+++ b/scripts/generate-template.py
@@ -52,6 +52,15 @@ class CFGroup:
         return [cf for cf in self.custom_formats if cf.is_optional]
 
     @property
+    def default_cfs(self) -> list[CustomFormat]:
+        return [cf for cf in self.custom_formats if cf.default]
+
+    @property
+    def has_body(self) -> bool:
+        """True when the group has any CF the user can toggle."""
+        return bool(self.default_cfs or self.optional_cfs)
+
+    @property
     def has_cf_defaults(self) -> bool:
         return any(cf.default for cf in self.custom_formats)
 
@@ -79,6 +88,7 @@ class TemplateSpec:
     optional_groups: list[CFGroup]
     default_groups: list[CFGroup]
     choice_groups: list[CFGroup]
+    conflict_sets: list[frozenset[str]] = field(default_factory=list)
 
 
 def load_guides(guides_path: Path) -> dict:
@@ -285,6 +295,80 @@ def comment_block(paragraphs: list[str], indent: int = 0) -> list[str]:
     return lines
 
 
+def group_has_conflict(group: CFGroup, conflict_sets: list[frozenset[str]]) -> bool:
+    """True when the group holds two or more members of one conflict set."""
+    ids = {cf.trash_id for cf in group.custom_formats}
+    return any(len(ids & cs) >= 2 for cs in conflict_sets)
+
+
+def masked_select_ids(group: CFGroup, conflict_sets: list[frozenset[str]]) -> set[str]:
+    """Optional CFs needing an extra comment level inside a commented block.
+
+    For each conflict set with two or more optional members in this group, the
+    first in guide order stays at the block's level and the rest are masked, so
+    uncommenting the block activates exactly one.
+    """
+    order = [cf.trash_id for cf in group.optional_cfs]
+    masked: set[str] = set()
+    for cs in conflict_sets:
+        present = [t for t in order if t in cs]
+        if len(present) >= 2:
+            masked.update(present[1:])
+    return masked
+
+
+def render_group_entry(
+    group: CFGroup,
+    conflict_sets: list[frozenset[str]],
+    *,
+    commented: bool,
+) -> list[str]:
+    """Render one entry under `add:`.
+
+    Uncommented (a group Recyclarr syncs by default):
+
+        - trash_id: <id>  # <name>
+          exclude:
+            # - <id>  # <name>      each `default` CF; uncomment to turn OFF
+          select:
+            # - <id>  # <name>      each optional CF; uncomment to turn ON
+
+    Commented (an opt-in group) is the same text with `# ` after the indent.
+    Inside a commented block, `exclude:` members carry an extra `# ` so that
+    enabling the group does not also strip its defaults, while `select:`
+    members sit at the block's own level so enabling the group includes them,
+    which is how opt-in groups already behave.
+
+    Required CFs are never listed: they are always included and cannot be
+    excluded.
+    """
+    indent = " " * 8
+    block = "# " if commented else ""
+    lines = [f"{indent}{block}- trash_id: {group.trash_id}  # {group.name}"]
+
+    masked = masked_select_ids(group, conflict_sets) if commented else set()
+    if group_has_conflict(group, conflict_sets):
+        lines.append(
+            f"{indent}{block}  "
+            "# Mutually exclusive: enable only one of the following."
+        )
+
+    for node, cfs in (("exclude", group.default_cfs), ("select", group.optional_cfs)):
+        if not cfs:
+            continue
+        lines.append(f"{indent}{block}  {node}:")
+        for cf in cfs:
+            if not commented:
+                mark = "# "
+            elif node == "exclude":
+                mark = "# "
+            else:
+                mark = "# " if cf.trash_id in masked else ""
+            lines.append(f"{indent}{block}    {mark}- {cf.trash_id}  # {cf.name}")
+
+    return lines
+
+
 def generate_yaml(spec: TemplateSpec) -> str:
     lines = []
 
@@ -329,17 +413,21 @@ def generate_yaml(spec: TemplateSpec) -> str:
         lines.append("    custom_format_groups:")
 
         if has_optional or has_choice:
-            simple = [g for g in spec.optional_groups if not g.optional_cfs]
-            expanded = [g for g in spec.optional_groups if g.optional_cfs]
+            simple = [g for g in spec.optional_groups if not g.has_body]
+            expanded = [g for g in spec.optional_groups if g.has_body]
             simple.sort(key=lambda g: g.name)
             expanded.sort(key=lambda g: g.name)
 
             lines.extend(
                 comment_block(
                     [
-                        "These groups are NOT synced by default. Uncomment to"
-                        " enable. Use `select:` to choose specific CFs within"
-                        " a group.",
+                        "Uncommented groups are synced by default. They are listed"
+                        " here so you can adjust which CFs they include. Commented"
+                        " groups are NOT synced; uncomment one to enable it.",
+                        "Within a group, uncomment a line under `select:` to turn"
+                        " an optional CF on, or under `exclude:` to turn a default"
+                        " CF off. Required CFs are always included and are not"
+                        " listed.",
                         "To uncomment, remove `# ` (hash + space) so that"
                         " indentation stays aligned. Most editors do this"
                         " automatically with toggle-comment (Ctrl+/).",
@@ -350,24 +438,18 @@ def generate_yaml(spec: TemplateSpec) -> str:
             )
             lines.append("      add:")
 
-            # Choice groups: uncommented, with select block
             for group in spec.choice_groups:
-                lines.append(f"        - trash_id: {group.trash_id}  # {group.name}")
-                lines.append("          select:")
-                for cf in group.custom_formats:
-                    if cf.default:
-                        lines.append(f"            - {cf.trash_id}  # {cf.name}")
-                    else:
-                        lines.append(f"            # - {cf.trash_id}  # {cf.name}")
-
-            # Optional groups: commented out
+                lines.extend(
+                    render_group_entry(group, spec.conflict_sets, commented=False)
+                )
             for group in simple:
-                lines.append(f"        # - trash_id: {group.trash_id}  # {group.name}")
+                lines.extend(
+                    render_group_entry(group, spec.conflict_sets, commented=True)
+                )
             for group in expanded:
-                lines.append(f"        # - trash_id: {group.trash_id}  # {group.name}")
-                lines.append("        #   select:")
-                for cf in group.optional_cfs:
-                    lines.append(f"        #     - {cf.trash_id}  # {cf.name}")
+                lines.extend(
+                    render_group_entry(group, spec.conflict_sets, commented=True)
+                )
 
         if has_default:
             lines.append("")

--- a/scripts/generate-template.py
+++ b/scripts/generate-template.py
@@ -169,6 +169,29 @@ def load_profile_groups(
     return []
 
 
+def load_conflicts(
+    guides_path: Path, json_paths: dict, service: str
+) -> list[frozenset[str]]:
+    """Load mutually exclusive CF sets from the guides.
+
+    Unlike the other resources, `conflicts` in metadata.json is a list of file
+    paths, not directories. A missing entry or file yields no sets, which makes
+    every conflict-driven behaviour inert rather than an error.
+    """
+    sets: list[frozenset[str]] = []
+    for rel_path in json_paths.get(service, {}).get("conflicts", []):
+        conflicts_file = guides_path / rel_path
+        if not conflicts_file.exists():
+            continue
+        with open(conflicts_file) as f:
+            data = json.load(f)
+        for entry in data.get("custom_formats", []):
+            ids = frozenset(entry)
+            if len(ids) >= 2:
+                sets.append(ids)
+    return sets
+
+
 def get_profile_group_name(
     profile_groups: list[dict], profile_trash_id: str
 ) -> str | None:
@@ -228,6 +251,7 @@ def build_template_specs(guides_path: Path) -> list[TemplateSpec]:
         profiles = load_profiles(guides_path, json_paths, service)
         cf_groups = load_cf_groups(guides_path, json_paths, service)
         profile_groups = load_profile_groups(guides_path, json_paths, service)
+        conflict_sets = load_conflicts(guides_path, json_paths, service)
 
         for profile in sorted(profiles.values(), key=lambda p: p.file_stem):
             group_name = get_profile_group_name(profile_groups, profile.trash_id)
@@ -256,6 +280,7 @@ def build_template_specs(guides_path: Path) -> list[TemplateSpec]:
                     optional_groups=optional,
                     default_groups=default,
                     choice_groups=choice,
+                    conflict_sets=conflict_sets,
                 )
             )
 

--- a/sonarr/templates/anime-remux-1080p.yml
+++ b/sonarr/templates/anime-remux-1080p.yml
@@ -30,6 +30,7 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -56,27 +57,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/anime-remux-1080p.yml
+++ b/sonarr/templates/anime-remux-1080p.yml
@@ -21,8 +21,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).

--- a/sonarr/templates/french-multi-vf-bluray-web-1080p.yml
+++ b/sonarr/templates/french-multi-vf-bluray-web-1080p.yml
@@ -36,6 +36,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:

--- a/sonarr/templates/french-multi-vf-bluray-web-1080p.yml
+++ b/sonarr/templates/french-multi-vf-bluray-web-1080p.yml
@@ -21,8 +21,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,23 +36,25 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          exclude:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian

--- a/sonarr/templates/french-multi-vf-bluray-web-1080p.yml
+++ b/sonarr/templates/french-multi-vf-bluray-web-1080p.yml
@@ -34,7 +34,22 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          select:
+            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
+            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -61,27 +76,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/french-multi-vf-bluray-web-2160p.yml
+++ b/sonarr/templates/french-multi-vf-bluray-web-2160p.yml
@@ -21,8 +21,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,23 +36,25 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          exclude:
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost

--- a/sonarr/templates/french-multi-vf-bluray-web-2160p.yml
+++ b/sonarr/templates/french-multi-vf-bluray-web-2160p.yml
@@ -34,14 +34,33 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          select:
+            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
+            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
@@ -64,31 +83,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/french-multi-vf-bluray-web-2160p.yml
+++ b/sonarr/templates/french-multi-vf-bluray-web-2160p.yml
@@ -36,6 +36,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
@@ -65,9 +66,10 @@ sonarr:
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD

--- a/sonarr/templates/french-multi-vo-bluray-web-1080p.yml
+++ b/sonarr/templates/french-multi-vo-bluray-web-1080p.yml
@@ -36,6 +36,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:

--- a/sonarr/templates/french-multi-vo-bluray-web-1080p.yml
+++ b/sonarr/templates/french-multi-vo-bluray-web-1080p.yml
@@ -21,8 +21,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,23 +36,25 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          exclude:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian

--- a/sonarr/templates/french-multi-vo-bluray-web-1080p.yml
+++ b/sonarr/templates/french-multi-vo-bluray-web-1080p.yml
@@ -34,7 +34,22 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          select:
+            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
+            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -61,27 +76,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/french-multi-vo-bluray-web-2160p.yml
+++ b/sonarr/templates/french-multi-vo-bluray-web-2160p.yml
@@ -21,8 +21,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,23 +36,25 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          exclude:
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost

--- a/sonarr/templates/french-multi-vo-bluray-web-2160p.yml
+++ b/sonarr/templates/french-multi-vo-bluray-web-2160p.yml
@@ -34,14 +34,33 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          select:
+            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
+            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
@@ -64,31 +83,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/french-multi-vo-bluray-web-2160p.yml
+++ b/sonarr/templates/french-multi-vo-bluray-web-2160p.yml
@@ -36,6 +36,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
@@ -65,9 +66,10 @@ sonarr:
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD

--- a/sonarr/templates/french-vostfr-bluray-web-1080p.yml
+++ b/sonarr/templates/french-vostfr-bluray-web-1080p.yml
@@ -36,6 +36,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:

--- a/sonarr/templates/french-vostfr-bluray-web-1080p.yml
+++ b/sonarr/templates/french-vostfr-bluray-web-1080p.yml
@@ -21,8 +21,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,23 +36,25 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          exclude:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian

--- a/sonarr/templates/french-vostfr-bluray-web-1080p.yml
+++ b/sonarr/templates/french-vostfr-bluray-web-1080p.yml
@@ -34,7 +34,22 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          select:
+            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
+            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -61,27 +76,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/french-vostfr-bluray-web-2160p.yml
+++ b/sonarr/templates/french-vostfr-bluray-web-2160p.yml
@@ -21,8 +21,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,23 +36,25 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          exclude:
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost

--- a/sonarr/templates/french-vostfr-bluray-web-2160p.yml
+++ b/sonarr/templates/french-vostfr-bluray-web-2160p.yml
@@ -34,14 +34,33 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: a23c8675c79118544fd74153394fa589  # [Unwanted] Unwanted Formats French
+          select:
+            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
+            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - 3ba797e5dc13af4b8d9bb25e83d90de2  # FR LQ
+            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
+            # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
+            # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
@@ -64,31 +83,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/french-vostfr-bluray-web-2160p.yml
+++ b/sonarr/templates/french-vostfr-bluray-web-2160p.yml
@@ -36,6 +36,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
@@ -65,9 +66,10 @@ sonarr:
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD

--- a/sonarr/templates/german-anime-hd-bluray-web.yml
+++ b/sonarr/templates/german-anime-hd-bluray-web.yml
@@ -33,6 +33,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:

--- a/sonarr/templates/german-anime-hd-bluray-web.yml
+++ b/sonarr/templates/german-anime-hd-bluray-web.yml
@@ -27,21 +27,28 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+        - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          select:
+            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - a6a6c33d057406aaad978a6902823c35  # German LQ
+            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -68,27 +75,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/german-anime-hd-bluray-web.yml
+++ b/sonarr/templates/german-anime-hd-bluray-web.yml
@@ -18,8 +18,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,25 +33,27 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          exclude:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - a6a6c33d057406aaad978a6902823c35  # German LQ
+            # - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            # - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian

--- a/sonarr/templates/german-hd-bluray-web.yml
+++ b/sonarr/templates/german-hd-bluray-web.yml
@@ -36,6 +36,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:

--- a/sonarr/templates/german-hd-bluray-web.yml
+++ b/sonarr/templates/german-hd-bluray-web.yml
@@ -21,8 +21,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,25 +36,27 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          exclude:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - a6a6c33d057406aaad978a6902823c35  # German LQ
+            # - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            # - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian

--- a/sonarr/templates/german-hd-bluray-web.yml
+++ b/sonarr/templates/german-hd-bluray-web.yml
@@ -34,21 +34,24 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - a6a6c33d057406aaad978a6902823c35  # German LQ
+            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -75,27 +78,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/german-hd-remux-web.yml
+++ b/sonarr/templates/german-hd-remux-web.yml
@@ -36,6 +36,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:

--- a/sonarr/templates/german-hd-remux-web.yml
+++ b/sonarr/templates/german-hd-remux-web.yml
@@ -21,8 +21,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,25 +36,27 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          exclude:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - a6a6c33d057406aaad978a6902823c35  # German LQ
+            # - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            # - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian

--- a/sonarr/templates/german-hd-remux-web.yml
+++ b/sonarr/templates/german-hd-remux-web.yml
@@ -34,21 +34,24 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - a6a6c33d057406aaad978a6902823c35  # German LQ
+            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -75,27 +78,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/sonarr/templates/german-uhd-bluray-web-alternative.yml
@@ -36,6 +36,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
@@ -67,9 +68,10 @@ sonarr:
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD

--- a/sonarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/sonarr/templates/german-uhd-bluray-web-alternative.yml
@@ -21,8 +21,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,25 +36,27 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          exclude:
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - a6a6c33d057406aaad978a6902823c35  # German LQ
+            # - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            # - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost

--- a/sonarr/templates/german-uhd-bluray-web-alternative.yml
+++ b/sonarr/templates/german-uhd-bluray-web-alternative.yml
@@ -30,36 +30,39 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
-          select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - a6a6c33d057406aaad978a6902823c35  # German LQ
+            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
@@ -82,31 +85,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/german-uhd-bluray-web.yml
+++ b/sonarr/templates/german-uhd-bluray-web.yml
@@ -36,6 +36,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
@@ -67,9 +68,10 @@ sonarr:
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD

--- a/sonarr/templates/german-uhd-bluray-web.yml
+++ b/sonarr/templates/german-uhd-bluray-web.yml
@@ -21,8 +21,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,25 +36,27 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          exclude:
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - a6a6c33d057406aaad978a6902823c35  # German LQ
+            # - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            # - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost

--- a/sonarr/templates/german-uhd-bluray-web.yml
+++ b/sonarr/templates/german-uhd-bluray-web.yml
@@ -30,36 +30,39 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
-          select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            - a6a6c33d057406aaad978a6902823c35  # German LQ
+            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
@@ -82,31 +85,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/german-uhd-remux-web.yml
+++ b/sonarr/templates/german-uhd-remux-web.yml
@@ -36,6 +36,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
@@ -67,9 +68,10 @@ sonarr:
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD

--- a/sonarr/templates/german-uhd-remux-web.yml
+++ b/sonarr/templates/german-uhd-remux-web.yml
@@ -21,8 +21,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -31,25 +36,27 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          exclude:
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - a6a6c33d057406aaad978a6902823c35  # German LQ
+            # - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
+            # - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost

--- a/sonarr/templates/remux-2160p-alternative.yml
+++ b/sonarr/templates/remux-2160p-alternative.yml
@@ -18,8 +18,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,41 +33,44 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          exclude:
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          exclude:
+            # - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
           select:
             # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
             # - ed51973a811f51985f14e2f6f290e47a  # German DL
             # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
             # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
             # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
             # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
             # - 133589380b89f8f8394320901529bac1  # Not German or English
             # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
             # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
             # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
-          select:
-            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
-            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+          exclude:
+            # - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            # - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
         - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs

--- a/sonarr/templates/remux-2160p-alternative.yml
+++ b/sonarr/templates/remux-2160p-alternative.yml
@@ -1,13 +1,10 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Remux + WEB
-##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-
-## en/#uhd-remux-web-2160p
+## TRaSH Guides: Remux 2160p (Alternative)
 ################################################################################
 
 sonarr:
-  sonarr-german-uhd-remux-web:
+  sonarr-remux-2160p-alternative:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +12,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 08cececf1840290f6fd490b7d79e8642  # [German] UHD Remux + WEB
+      - trash_id: 361717d531db5a6002e0f547ace46551  # Remux 2160p (Alternative)
         reset_unmatched_scores:
           enabled: true
 
@@ -34,23 +31,38 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
+        - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
+          select:
+            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
-        # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
@@ -58,7 +70,10 @@ sonarr:
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
+        #   select:
+        #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
+        #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR

--- a/sonarr/templates/remux-2160p-alternative.yml
+++ b/sonarr/templates/remux-2160p-alternative.yml
@@ -33,6 +33,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
@@ -83,9 +84,10 @@ sonarr:
         #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
         #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD

--- a/sonarr/templates/remux-2160p-combined.yml
+++ b/sonarr/templates/remux-2160p-combined.yml
@@ -18,8 +18,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,41 +33,44 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          exclude:
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          exclude:
+            # - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
           select:
             # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
             # - ed51973a811f51985f14e2f6f290e47a  # German DL
             # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
             # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
             # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
             # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
             # - 133589380b89f8f8394320901529bac1  # Not German or English
             # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
             # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
             # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
-          select:
-            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
-            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+          exclude:
+            # - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            # - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
         - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs

--- a/sonarr/templates/remux-2160p-combined.yml
+++ b/sonarr/templates/remux-2160p-combined.yml
@@ -33,6 +33,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
@@ -83,9 +84,10 @@ sonarr:
         #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
         #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD

--- a/sonarr/templates/remux-2160p-combined.yml
+++ b/sonarr/templates/remux-2160p-combined.yml
@@ -1,13 +1,10 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Remux + WEB
-##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-
-## en/#uhd-remux-web-2160p
+## TRaSH Guides: Remux 2160p (Combined)
 ################################################################################
 
 sonarr:
-  sonarr-german-uhd-remux-web:
+  sonarr-remux-2160p-combined:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +12,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 08cececf1840290f6fd490b7d79e8642  # [German] UHD Remux + WEB
+      - trash_id: 911df0e05a395c19d8b3efc76a7467c1  # Remux 2160p (Combined)
         reset_unmatched_scores:
           enabled: true
 
@@ -34,23 +31,38 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
+        - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
+          select:
+            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
-        # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
@@ -58,7 +70,10 @@ sonarr:
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
+        #   select:
+        #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
+        #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR

--- a/sonarr/templates/remux-web-1080p.yml
+++ b/sonarr/templates/remux-web-1080p.yml
@@ -18,8 +18,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,41 +33,44 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          exclude:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          exclude:
+            # - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
           select:
             # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
             # - ed51973a811f51985f14e2f6f290e47a  # German DL
             # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
             # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
             # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
             # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
             # - 133589380b89f8f8394320901529bac1  # Not German or English
             # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
             # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
             # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
-          select:
-            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
-            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+          exclude:
+            # - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            # - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
         - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian

--- a/sonarr/templates/remux-web-1080p.yml
+++ b/sonarr/templates/remux-web-1080p.yml
@@ -33,6 +33,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:

--- a/sonarr/templates/remux-web-1080p.yml
+++ b/sonarr/templates/remux-web-1080p.yml
@@ -1,13 +1,10 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Remux + WEB
-##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-
-## en/#uhd-remux-web-2160p
+## TRaSH Guides: Remux + WEB 1080p
 ################################################################################
 
 sonarr:
-  sonarr-german-uhd-remux-web:
+  sonarr-remux-web-1080p:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +12,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 08cececf1840290f6fd490b7d79e8642  # [German] UHD Remux + WEB
+      - trash_id: fe9470e577c300a5ad9a3274f6d1cdf2  # Remux + WEB 1080p
         reset_unmatched_scores:
           enabled: true
 
@@ -30,39 +27,51 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       add:
-        - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+        - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
           select:
-            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
+        - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
+          select:
+            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
-        # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
-        # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
-        # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
         #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
+        #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
@@ -103,5 +112,4 @@ sonarr:
       ## https://recyclarr.dev/guide/cf-groups/
       ################################################################################
       skip:
-        # - 7e1724c5da59e7474803ad25be98f6a3  # [HDR Formats] HDR
         # - abe720fab2d27682adc2a735136cec02  # [Streaming Services] General

--- a/sonarr/templates/remux-web-2160p.yml
+++ b/sonarr/templates/remux-web-2160p.yml
@@ -18,8 +18,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -28,41 +33,44 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          exclude:
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          exclude:
+            # - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
           select:
             # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
             # - ed51973a811f51985f14e2f6f290e47a  # German DL
             # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
             # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
             # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
             # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
             # - 133589380b89f8f8394320901529bac1  # Not German or English
             # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
             # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
             # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
-          select:
-            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
-            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+          exclude:
+            # - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            # - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
         - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs

--- a/sonarr/templates/remux-web-2160p.yml
+++ b/sonarr/templates/remux-web-2160p.yml
@@ -1,13 +1,10 @@
 # yaml-language-server: $schema=https://schemas.recyclarr.dev/v8/config-schema.json
 ################################################################################
-## TRaSH Guides: [German] UHD Remux + WEB
-##
-## https://trash-guides.info/Sonarr/sonarr-setup-quality-profiles-german-
-## en/#uhd-remux-web-2160p
+## TRaSH Guides: Remux + WEB 2160p
 ################################################################################
 
 sonarr:
-  sonarr-german-uhd-remux-web:
+  sonarr-remux-web-2160p:
     base_url: Put your Sonarr URL here
     api_key: Put your API key here
 
@@ -15,7 +12,7 @@ sonarr:
       type: series
 
     quality_profiles:
-      - trash_id: 08cececf1840290f6fd490b7d79e8642  # [German] UHD Remux + WEB
+      - trash_id: 76a5053bdb2d1e4a8f16a69a37d46c12  # Remux + WEB 2160p
         reset_unmatched_scores:
           enabled: true
 
@@ -34,23 +31,38 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
-        - trash_id: 6f0872eebfc95b1f93474b7ac866ced0  # [Unwanted] Unwanted Formats German
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
+        - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
+          select:
+            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+        - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
           select:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - a6a6c33d057406aaad978a6902823c35  # German LQ
-            - d80c9f7cd2aad50271f1bd4e53125778  # German LQ (release title)
-            - 237eda4ef550a97da2c9d87b437e500b  # German Microsized
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
+            # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
-        # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
@@ -58,7 +70,10 @@ sonarr:
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
-        # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
+        #   select:
+        #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
+        #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR

--- a/sonarr/templates/remux-web-2160p.yml
+++ b/sonarr/templates/remux-web-2160p.yml
@@ -33,6 +33,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
@@ -83,9 +84,10 @@ sonarr:
         #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
         #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD

--- a/sonarr/templates/web-1080p-alternative.yml
+++ b/sonarr/templates/web-1080p-alternative.yml
@@ -20,8 +20,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -30,41 +35,44 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          exclude:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          exclude:
+            # - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
           select:
             # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
             # - ed51973a811f51985f14e2f6f290e47a  # German DL
             # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
             # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
             # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
             # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
             # - 133589380b89f8f8394320901529bac1  # Not German or English
             # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
             # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
             # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
-          select:
-            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
-            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+          exclude:
+            # - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            # - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
         - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian

--- a/sonarr/templates/web-1080p-alternative.yml
+++ b/sonarr/templates/web-1080p-alternative.yml
@@ -35,6 +35,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:

--- a/sonarr/templates/web-1080p-alternative.yml
+++ b/sonarr/templates/web-1080p-alternative.yml
@@ -33,6 +33,19 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
           select:
             - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
@@ -42,7 +55,8 @@ sonarr:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
             - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
@@ -51,30 +65,22 @@ sonarr:
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
-        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
+        #   select:
+        #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
+        #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
         #     - c196536ea8122397c5854040d01f2aa7  # WiTH ASL
         #     - b40dc2e630723745aab9f1b94f4aab74  # WiTH BASL
         #     - 0aef382c4ed4c5eb5d40109dfd351b72  # WiTH BSL
-        # - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
-        #   select:
-        #     - 8a9fcdbb445f2add0505926df3bb7b8a  # German
-        #     - ed51973a811f51985f14e2f6f290e47a  # German DL
-        #     - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
-        #     - 21d4ae0976f7a4c251884d26fc46183c  # German Subbed
-        #     - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
-        #     - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-        #     - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
-        #     - 133589380b89f8f8394320901529bac1  # Not German or English
-        #     - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
-        #     - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
         # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         #   select:
         #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
@@ -91,27 +97,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/web-1080p.yml
+++ b/sonarr/templates/web-1080p.yml
@@ -20,8 +20,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -30,41 +35,44 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          exclude:
+            # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:
-            - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          exclude:
+            # - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
           select:
             # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
             # - ed51973a811f51985f14e2f6f290e47a  # German DL
             # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
             # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
             # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
             # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
             # - 133589380b89f8f8394320901529bac1  # Not German or English
             # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
             # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
             # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
-          select:
-            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
-            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+          exclude:
+            # - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            # - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
         - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
         # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian

--- a/sonarr/templates/web-1080p.yml
+++ b/sonarr/templates/web-1080p.yml
@@ -33,6 +33,19 @@ sonarr:
           select:
             - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
           select:
             - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
@@ -42,7 +55,8 @@ sonarr:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
             - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
@@ -52,6 +66,7 @@ sonarr:
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
@@ -62,18 +77,6 @@ sonarr:
         #     - c196536ea8122397c5854040d01f2aa7  # WiTH ASL
         #     - b40dc2e630723745aab9f1b94f4aab74  # WiTH BASL
         #     - 0aef382c4ed4c5eb5d40109dfd351b72  # WiTH BSL
-        # - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
-        #   select:
-        #     - 8a9fcdbb445f2add0505926df3bb7b8a  # German
-        #     - ed51973a811f51985f14e2f6f290e47a  # German DL
-        #     - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
-        #     - 21d4ae0976f7a4c251884d26fc46183c  # German Subbed
-        #     - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
-        #     - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-        #     - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
-        #     - 133589380b89f8f8394320901529bac1  # Not German or English
-        #     - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
-        #     - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
         # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         #   select:
         #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
@@ -90,27 +93,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/web-1080p.yml
+++ b/sonarr/templates/web-1080p.yml
@@ -35,6 +35,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: 158188097a58d7687dee647e04af0da3  # [Optional] Golden Rule HD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
           select:

--- a/sonarr/templates/web-2160p-alternative.yml
+++ b/sonarr/templates/web-2160p-alternative.yml
@@ -33,6 +33,19 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
           select:
             - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
@@ -42,7 +55,8 @@ sonarr:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
             - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
@@ -51,33 +65,29 @@ sonarr:
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
             - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
-        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e9a1944a254e6f8a9da63083f7ae15cb  # [Audio] Audio Formats
+        #   select:
+        #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
+        #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
         #     - c196536ea8122397c5854040d01f2aa7  # WiTH ASL
         #     - b40dc2e630723745aab9f1b94f4aab74  # WiTH BASL
         #     - 0aef382c4ed4c5eb5d40109dfd351b72  # WiTH BSL
-        # - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
-        #   select:
-        #     - 8a9fcdbb445f2add0505926df3bb7b8a  # German
-        #     - ed51973a811f51985f14e2f6f290e47a  # German DL
-        #     - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
-        #     - 21d4ae0976f7a4c251884d26fc46183c  # German Subbed
-        #     - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
-        #     - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-        #     - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
-        #     - 133589380b89f8f8394320901529bac1  # Not German or English
-        #     - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
-        #     - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
         # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         #   select:
         #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
@@ -94,31 +104,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/web-2160p-alternative.yml
+++ b/sonarr/templates/web-2160p-alternative.yml
@@ -20,8 +20,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -30,41 +35,44 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          exclude:
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          exclude:
+            # - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
           select:
             # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
             # - ed51973a811f51985f14e2f6f290e47a  # German DL
             # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
             # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
             # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
             # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
             # - 133589380b89f8f8394320901529bac1  # Not German or English
             # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
             # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
             # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
-          select:
-            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
-            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+          exclude:
+            # - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            # - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
         - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost

--- a/sonarr/templates/web-2160p-alternative.yml
+++ b/sonarr/templates/web-2160p-alternative.yml
@@ -35,6 +35,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
@@ -87,9 +88,10 @@ sonarr:
         #     - 3e8b714263b26f486972ee1e0fe7606c  # MP3
         #     - 28f6ef16d61e2d1adfce3156ed8257e3  # Opus
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD

--- a/sonarr/templates/web-2160p-combined.yml
+++ b/sonarr/templates/web-2160p-combined.yml
@@ -35,6 +35,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
@@ -83,9 +84,10 @@ sonarr:
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD

--- a/sonarr/templates/web-2160p-combined.yml
+++ b/sonarr/templates/web-2160p-combined.yml
@@ -20,8 +20,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -30,41 +35,44 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          exclude:
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          exclude:
+            # - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
           select:
             # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
             # - ed51973a811f51985f14e2f6f290e47a  # German DL
             # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
             # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
             # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
             # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
             # - 133589380b89f8f8394320901529bac1  # Not German or English
             # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
             # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
             # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
-          select:
-            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
-            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+          exclude:
+            # - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            # - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
         - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost

--- a/sonarr/templates/web-2160p-combined.yml
+++ b/sonarr/templates/web-2160p-combined.yml
@@ -33,6 +33,19 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
           select:
             - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
@@ -42,7 +55,8 @@ sonarr:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
             - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
@@ -55,28 +69,21 @@ sonarr:
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
         #     - c196536ea8122397c5854040d01f2aa7  # WiTH ASL
         #     - b40dc2e630723745aab9f1b94f4aab74  # WiTH BASL
         #     - 0aef382c4ed4c5eb5d40109dfd351b72  # WiTH BSL
-        # - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
-        #   select:
-        #     - 8a9fcdbb445f2add0505926df3bb7b8a  # German
-        #     - ed51973a811f51985f14e2f6f290e47a  # German DL
-        #     - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
-        #     - 21d4ae0976f7a4c251884d26fc46183c  # German Subbed
-        #     - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
-        #     - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-        #     - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
-        #     - 133589380b89f8f8394320901529bac1  # Not German or English
-        #     - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
-        #     - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
         # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         #   select:
         #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
@@ -93,31 +100,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/sonarr/templates/web-2160p.yml
+++ b/sonarr/templates/web-2160p.yml
@@ -35,6 +35,7 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          # Mutually exclusive: enable only one of the following.
           exclude:
             # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
@@ -83,9 +84,10 @@ sonarr:
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
         # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   # Mutually exclusive: enable only one of the following.
         #   select:
         #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
+        #     # - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD

--- a/sonarr/templates/web-2160p.yml
+++ b/sonarr/templates/web-2160p.yml
@@ -20,8 +20,13 @@ sonarr:
 
     custom_format_groups:
       ################################################################################
-      ## These groups are NOT synced by default. Uncomment to enable. Use `select:` to
-      ## choose specific CFs within a group.
+      ## Uncommented groups are synced by default. They are listed here so you can
+      ## adjust which CFs they include. Commented groups are NOT synced; uncomment one
+      ## to enable it.
+      ##
+      ## Within a group, uncomment a line under `select:` to turn an optional CF on,
+      ## or under `exclude:` to turn a default CF off. Required CFs are always
+      ## included and are not listed.
       ##
       ## To uncomment, remove `# ` (hash + space) so that indentation stays aligned.
       ## Most editors do this automatically with toggle-comment (Ctrl+/).
@@ -30,41 +35,44 @@ sonarr:
       ################################################################################
       add:
         - trash_id: e3f37512790f00d0e89e54fe5e790d1c  # [Optional] Golden Rule UHD
+          exclude:
+            # - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-            - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
         - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          exclude:
+            # - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
           select:
             # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
             # - ed51973a811f51985f14e2f6f290e47a  # German DL
             # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
             # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
             # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
             # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
             # - 133589380b89f8f8394320901529bac1  # Not German or English
             # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
             # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
             # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
-          select:
-            - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
-            - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
+          exclude:
+            # - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
+            # - 43b3cf48cb385cd3eac608ee6bca7f09  # UHD Streaming Boost
         - trash_id: 59c3af66780d08332fdc64e68297098f  # [Unwanted] Unwanted Formats
+          exclude:
+            # - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+            # - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
+            # - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
+            # - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
+            # - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
+            # - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
+            # - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
           select:
-            - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
-            - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
-            - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
             # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
             # - 21d9d08e39b05523ec36811ab06b8308  # BW
-            - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
-            - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
-            - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
             # - 82d40da2bc6923f41e14394075dd4b03  # No-RlsGroup
             # - e1a997ddb54e3ecbfe06341ad323c458  # Obfuscated
             # - 06d66ab109d4d2eddb2794d21526d140  # Retags
             # - 1b3994c551cbb92a2c781af061f4ab44  # Scene
-            - 23297a736ca77c0fc8e70f8edd7ee56c  # Upscaled
         # - trash_id: d776a1ea912a117d66d83b880ff2055d  # [HDR Formats] DV (w/o HDR fallback)
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost

--- a/sonarr/templates/web-2160p.yml
+++ b/sonarr/templates/web-2160p.yml
@@ -33,6 +33,19 @@ sonarr:
           select:
             # - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
             - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+        - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
+          select:
+            # - 8a9fcdbb445f2add0505926df3bb7b8a  # German
+            # - ed51973a811f51985f14e2f6f290e47a  # German DL
+            # - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
+            # - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
+            # - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
+            - ae575f95ab639ba5d15f663bf019e3e8  # Language: Not Original
+            # - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
+            # - 133589380b89f8f8394320901529bac1  # Not German or English
+            # - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
+            # - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
+            # - 1fb6283bd05ab5c6a728cb213e5d07d8  # Wrong Language
         - trash_id: 85fae4a2294965b75710ef2989c850eb  # [Streaming Services] HD/UHD boost
           select:
             - 218e93e5702f44a68ad9e3c6ba87d2f0  # HD Streaming Boost
@@ -42,7 +55,8 @@ sonarr:
             - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
             - 32b367365729d530ca1c124a0b180c64  # Bad Dual Groups
             - 85c61753df5da1fb2aab6f2a47426b09  # BR-DISK
-            - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 6f808933a71bd9666531610cb8c059cc  # BR-DISK (BTN)
+            # - 21d9d08e39b05523ec36811ab06b8308  # BW
             - fbcb31d8dabd2a319072b84fc0b7249c  # Extras
             - 9c11cd3f07101cdba90a2d81cf0e56b4  # LQ
             - e2315f990da2e2cbfc9fa5b7a6fcfe48  # LQ (Release Title)
@@ -55,28 +69,21 @@ sonarr:
         # - trash_id: e0b2774083df4265f25c9e5bc6c80940  # [HDR Formats] DV Boost
         # - trash_id: 7d366c213e5c23a052b157356fac1921  # [HDR Formats] HDR10+ Boost
         # - trash_id: d920fd959d220306888f40b6f38e1578  # [Optional] Season Packs
+        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
         # - trash_id: 35fb4585dcd9e2a5ac732e4309f5a45a  # [Streaming Services] Asian
         # - trash_id: f60f4401ce880aad62e9d21c8bb6b91a  # [Streaming Services] Dutch
         # - trash_id: 848fd356c200568fc5a6248150e7e7ea  # [Streaming Services] French
         # - trash_id: ddab3095a5d2f436f369263840af34f9  # [Streaming Services] UK
+        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [HDR Formats] SDR
+        #   select:
+        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
+        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
         # - trash_id: bad5bc85573a0134e1e1987c46f67e98  # [Optional] Accessibility
         #   select:
         #     - 44ccbcbc74506f208973e1463b11705f  # WiTH AD
         #     - c196536ea8122397c5854040d01f2aa7  # WiTH ASL
         #     - b40dc2e630723745aab9f1b94f4aab74  # WiTH BASL
         #     - 0aef382c4ed4c5eb5d40109dfd351b72  # WiTH BSL
-        # - trash_id: 74aff4168620ed49dcc67e92b2c2a5b4  # [Optional] Language Profiles
-        #   select:
-        #     - 8a9fcdbb445f2add0505926df3bb7b8a  # German
-        #     - ed51973a811f51985f14e2f6f290e47a  # German DL
-        #     - c5dd0fd675f85487ad5bdf97159180bd  # German DL (undefined)
-        #     - 21d4ae0976f7a4c251884d26fc46183c  # German Subbed
-        #     - 69aa1e159f97d860440b04cd6d590c4f  # Language: Not English
-        #     - 322fca6f8f3694acc1401ddb530fd33d  # Language: Not French
-        #     - 10e77b96ae4770a7de645a91a53ce29a  # Language: Original + French
-        #     - 133589380b89f8f8394320901529bac1  # Not German or English
-        #     - 51ba9721e1d951e9ffccb3d939831941  # Not German, Japanese or English
-        #     - 1d1481d01b60a0274d81685b3ccbf7d0  # Not German, Japanese, Korean, Chinese or English
         # - trash_id: f4a0410a1df109a66d6e47dcadcce014  # [Optional] Miscellaneous
         #   select:
         #     - ef4963043b0987f8485bc9106f16db38  # DV (Disk)
@@ -93,31 +100,17 @@ sonarr:
         #     - cddfb4e32db826151d97352b8e37c648  # x264
         #     - c9eafd50846d299b862ca9bb6ea91950  # x265
         #     - 041d90b435ebd773271cea047a457a6a  # x266
-        # - trash_id: e1053c0ef622df3749fa43c22865663a  # [Optional] SDR
-        #   select:
-        #     - 2016d1676f5ee13a5b7257ff86ac9a93  # SDR
-        #     - 83304f261cf516bb208c18c54c0adf97  # SDR (no WEBDL)
-        # - trash_id: f54985e5e96747cef58731f1cf4c9181  # [Streaming Services] Anime
-        #   select:
-        #     - a370d974bc7b80374de1d9ba7519760b  # ABEMA
-        #     - d54cd2bf1326287275b56bccedb72ee2  # ADN
-        #     - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
-        #     - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
-        #     - 3e0b26604165f463f3e8e192261e7284  # CR
-        #     - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
-        #     - 570b03b3145a25011bf073274a407259  # HIDIVE
-        #     - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
-        #     - e5e6405d439dcd1af90962538acd4fe0  # WKN
         # - trash_id: 7832db22b71ab669458c17a2850d6913  # [Streaming Services] Miscellaneous
         #   select:
         #     - e6e299075e22ac8f541f722254c8350a  # AUBC
         #     - defb0b4c8b3f6a15927c0f14c6e69c94  # CBC
+        #     - 543b0fb529e6b102837b8a9facdd82fb  # CNLP
         #     - 4e9a630db98d5391aec1368a0256e2fe  # CRAV
         #     - dc5f2bb0e0262155b5fedd0f6c5d2b55  # DSCP
         #     - fb1a91cdc0f26f7ca0696e0e95274645  # OViD
-        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
-        #     - c30d2958827d1867c73318a5a2957eb1  # RED
         #     - 3ac5d84fce98bab1b531393e9c82f467  # QIBI
+        #     - c30d2958827d1867c73318a5a2957eb1  # RED
+        #     - fe4062eac43d4ea75955f8ae48adcf1e  # STRP
 
       ################################################################################
       ## These groups ARE synced by default. Uncomment to disable.

--- a/templates.json
+++ b/templates.json
@@ -82,19 +82,19 @@
     },
     {
       "template": "radarr/templates/remux-2160p-alternative.yml",
-      "id": "remux-2160p-alternative"
+      "id": "radarr-remux-2160p-alternative"
     },
     {
       "template": "radarr/templates/remux-2160p-combined.yml",
-      "id": "remux-2160p-combined"
+      "id": "radarr-remux-2160p-combined"
     },
     {
       "template": "radarr/templates/remux-web-1080p.yml",
-      "id": "remux-web-1080p"
+      "id": "radarr-remux-web-1080p"
     },
     {
       "template": "radarr/templates/remux-web-2160p.yml",
-      "id": "remux-web-2160p"
+      "id": "radarr-remux-web-2160p"
     },
     {
       "template": "radarr/templates/sqp/sqp-1-1080p.yml",
@@ -193,6 +193,22 @@
     {
       "template": "sonarr/templates/german-uhd-remux-web.yml",
       "id": "sonarr-german-uhd-remux-web"
+    },
+    {
+      "template": "sonarr/templates/remux-2160p-alternative.yml",
+      "id": "sonarr-remux-2160p-alternative"
+    },
+    {
+      "template": "sonarr/templates/remux-2160p-combined.yml",
+      "id": "sonarr-remux-2160p-combined"
+    },
+    {
+      "template": "sonarr/templates/remux-web-1080p.yml",
+      "id": "sonarr-remux-web-1080p"
+    },
+    {
+      "template": "sonarr/templates/remux-web-2160p.yml",
+      "id": "sonarr-remux-web-2160p"
     },
     {
       "template": "sonarr/templates/web-1080p.yml",


### PR DESCRIPTION
## Summary

Makes every commented line in a generated template do what it looks like it does, and stops the
templates inviting users to enable two mutually exclusive custom formats.

Stacked on #184. Until that merges, the diff here also shows its commit; review that one first.

## The problem

Templates listed a group's default CFs uncommented under `select:`:

```yaml
- trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
  select:
    # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
    - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
```

That assumed pre-8.1.0 semantics where `select:` replaced a group's defaults. Since 8.1.0 the
effective set is `required + (default - exclude) + select`, so those lines were inert. Two
consequences:

1. Commenting out a listed default did nothing. Recyclarr 8.1.x-8.4.x reported each as a redundant
   selection; 8.5.0 downgraded that to debug, so it went quiet but stayed wrong.
2. Following the implied instruction to swap produced **both** CFs. For Golden Rule that is
   `x265 (HD)` and `x265 (no HDR/DV)` together, which the guides document as mutually exclusive.

## The change

One rule now covers every group under `add:`:

| CF flag | Rendered as |
| --- | --- |
| `required` | not listed; always included and cannot be excluded |
| `default` | commented under `exclude:`; uncomment to turn OFF |
| neither | commented under `select:`; uncomment to turn ON |

```yaml
- trash_id: ff204bbcecdd487d1cefcefdbf0c278d  # [Optional] Golden Rule UHD
  # Mutually exclusive: enable only one of the following.
  exclude:
    # - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
  select:
    # - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
```

The node keys stay uncommented in an active group, so toggling a CF is one uncomment rather than
two. An empty node is valid: Recyclarr's schema types both as `["null", "array"]` and maps null to
an empty list.

`conflicts.json` drives two things. Groups holding two or more members of a conflict set gain the
note above. And in a commented opt-in group whose conflicting members all sit under `select:`, one
member stays at the block's own comment level while the rest nest one deeper, so uncommenting the
block enables exactly one:

```yaml
# - trash_id: 47f0d69750de9e16855915fa73bb7b08  # [HDR Formats] SDR
#   # Mutually exclusive: enable only one of the following.
#   select:
#     - 9c38ebb7384dada637be8899efa68e6f  # SDR
#     # - 25c12f78430a3a23413652cbd1d48d77  # SDR (no WEBDL)
```

Conflict sets are read via `metadata.json` `json_paths.<service>.conflicts`, so new sets are picked
up without a code change, sets of three or more members are handled generically, and a missing file
makes the behaviour inert rather than an error. Six groups currently carry a pair, producing 82
notes.

## New CI check

`ci/check_conflicting_cfs.py`, added as a step to the existing trash-ids workflow so it reuses that
job's guides checkout.

- **Pass A** resolves each template's effective CF set and fails if it holds more than one member of
  a conflict set.
- **Pass B** checks that within a commented group block at most one member sits at the block's own
  comment level.

Written in Python rather than PowerShell so it imports the generator's loaders directly, which keeps
the check and the generator reading guides data the same way. A guides checkout with no `conflicts`
entry warns and passes, since that file is not ours to guarantee.

## Verification

The rendering change must not alter what anyone syncs. Every template's effective CF set was
resolved before and after and compared:

```
differing templates: 0
```

across all 57 templates. That was treated as a merge gate, not a formality.

Both CI passes were proven to fail rather than assumed to work: Pass A against a deliberately
uncommented `x265 (HD)`, Pass B against a flattened SDR block. Both fixtures reverted.

`templates.json` is unchanged. No template or include IDs change, so this is not a breaking change.

Also clean: `yamllint .`, `CheckInvalidTemplatePaths.ps1`, `CheckInvalidTrashIds.ps1`, and
`pre-commit` on every changed file.
